### PR TITLE
fix(docker): patch CVE-2026-25547 brace-expansion 5.0.0 -> 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Docker CVE-2026-25547 Remediation** — Manually updated npm's bundled `@isaacs/brace-expansion` from 5.0.0 to 5.0.1 in Dockerfile to fix Inefficient Regular Expression Complexity vulnerability (HIGH). Applied to both builder and production stages
 - **Docker CVE-2026-24842 Remediation** — Upgraded manual `tar` patch in Dockerfile from version 7.5.4 to 7.5.7 to fix Path Traversal vulnerability (CVSS 8.2). Applied to both builder and production stages. Docker Scout scan now reports 0 fixable critical/high CVEs
 - **Enhanced Log Sanitization** — Upgraded logger to match db-mcp security standards
   - Added `sanitizeStack()` function to replace newlines with safe arrow delimiters (`→`) in stack traces

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
 
+# Fix CVE-2026-25547: Manually update npm's bundled @isaacs/brace-expansion@5.0.0 to 5.0.1
+RUN cd /usr/local/lib/node_modules/npm && \
+    npm pack @isaacs/brace-expansion@5.0.1 && \
+    rm -rf node_modules/@isaacs/brace-expansion && \
+    mkdir -p node_modules/@isaacs/brace-expansion && \
+    tar -xzf isaacs-brace-expansion-5.0.1.tgz && \
+    mv package/* node_modules/@isaacs/brace-expansion/ && \
+    rm -rf package isaacs-brace-expansion-5.0.1.tgz
+
 # Fix CVE-2026-23950, CVE-2026-24842: Manually update npm's bundled tar to 7.5.7
 RUN cd /usr/local/lib/node_modules/npm && \
     npm pack tar@7.5.7 && \
@@ -58,6 +67,15 @@ RUN cd /usr/local/lib/node_modules/npm && \
     tar -xzf diff-8.0.3.tgz && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
+
+# Fix CVE-2026-25547: Manually update npm's bundled @isaacs/brace-expansion@5.0.0 to 5.0.1
+RUN cd /usr/local/lib/node_modules/npm && \
+    npm pack @isaacs/brace-expansion@5.0.1 && \
+    rm -rf node_modules/@isaacs/brace-expansion && \
+    mkdir -p node_modules/@isaacs/brace-expansion && \
+    tar -xzf isaacs-brace-expansion-5.0.1.tgz && \
+    mv package/* node_modules/@isaacs/brace-expansion/ && \
+    rm -rf package isaacs-brace-expansion-5.0.1.tgz
 
 # Fix CVE-2026-23950, CVE-2026-24842: Manually update npm's bundled tar to 7.5.7
 RUN cd /usr/local/lib/node_modules/npm && \


### PR DESCRIPTION
Patches npm's bundled `@isaacs/brace-expansion@5.0.0` to 5.0.1 in both Dockerfile stages to fix HIGH severity CVE-2026-25547 (Inefficient Regular Expression Complexity). This was blocking the Docker deploy security scan after v1.2.0 release.