### PR TITLE
ci: add .gitleaks.toml allowlist for benchmark test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks Configuration
+# https://github.com/gitleaks/gitleaks#configuration
+
+title = "postgres-mcp gitleaks config"
+
+# Allowlist for known false positives in test fixtures
+[allowlist]
+  description = "Test fixtures containing intentionally fake secrets for benchmarking"
+  paths = [
+    '''src/__tests__/benchmarks/logger-sanitization\.bench\.ts''',
+  ]


### PR DESCRIPTION
False positive: `logger-sanitization.bench.ts` contains intentionally fake JWT tokens and API keys for benchmarking the logger's sensitive data redaction. This allowlist prevents gitleaks from flagging them.