### PR TITLE
security: fix CVE-2026-27904, CVE-2026-27903 (minimatch ReDoS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`secrets-scanning.yml` Gitleaks CI failure on PRs** — Added `GITHUB_TOKEN` environment variable to the `gitleaks/gitleaks-action@v2` step. Gitleaks Action v2 now requires `GITHUB_TOKEN` to scan pull requests, causing all PR CI checks to fail with `GITHUB_TOKEN is now required to scan pull requests`
 
+### Security
+
+- **CVE-2026-27904, CVE-2026-27903 (minimatch ReDoS)** — Updated `minimatch` override from `>=10.2.1` to `>=10.2.3` in `package.json` and added Dockerfile patch for npm's bundled minimatch
+
 ### Removed
 
 - **`security-update.yml` Trivy workflow** — Removed the dedicated Trivy security scanning workflow. Docker Scout in `docker-publish.yml` already provides container security scanning as a gate before pushing images, making Trivy redundant. The Trivy Action (`aquasecurity/trivy-action@0.34.1`) was also experiencing transient binary installation failures blocking unrelated PRs

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,14 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/tar && \
     rm tar-7.5.8.tgz
 
+# Fix CVE-2026-27904, CVE-2026-27903: Manually update npm's bundled minimatch to 10.2.3+
+RUN cd /usr/local/lib/node_modules/npm && \
+    npm pack minimatch@latest && \
+    rm -rf node_modules/minimatch && \
+    tar -xzf minimatch-*.tgz && \
+    mv package node_modules/minimatch && \
+    rm minimatch-*.tgz
+
 # Copy built artifacts and production dependencies
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "minimatch": ">=10.2.1",
+    "minimatch": ">=10.2.3",
     "tar": ">=7.5.8"
   }
 }


### PR DESCRIPTION
Updates minimatch override from >=10.2.1 to >=10.2.3 and patches npm's bundled minimatch in the Dockerfile to fix two HIGH CVEs (ReDoS + algorithmic complexity).