### PR TITLE
Update Dockerfile to use ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     fi
 
 # Run the MCP server (default: stdio transport)
-CMD ["node", "dist/cli.js"]
+ENTRYPOINT ["node", "dist/cli.js"]
+CMD []
 
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"


### PR DESCRIPTION
Replaced `CMD` with `ENTRYPOINT` in the Docker container configuration to fix argument-passing issues.

## Description

Running the container with the `--tool-filter starter` flag previously resulted in the following error:

```bash
docker run --rm -i \
  -e POSTGRES_HOST \
  -e POSTGRES_PORT \
  -e POSTGRES_USER \
  -e POSTGRES_PASSWORD \
  -e POSTGRES_DATABASE \
  writenotenow/postgres-mcp:latest \
  --tool-filter starter
```

Error output:

```
node: bad option: --tool-filter
```

This occurred because `ENTRYPOINT` was not properly defined in the `Dockerfile`, causing runtime arguments to be interpreted incorrectly.  

Switching from `CMD` to `ENTRYPOINT` ensures that command-line arguments are correctly forwarded to the container’s application.

## Type

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation  

## Checklist

- [x] Tested locally  
- [x] Updated documentation (if required)  