### PR TITLE
v3.0.3 - Nested Vulnerability Patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ RUN cd /usr/local/lib/node_modules/npm && \
 # Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
 RUN cd /usr/local/lib/node_modules/npm && \
     npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/picomatch && \
+    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
     tar -xzf picomatch-4.0.4.tgz && \
-    mv package node_modules/picomatch && \
+    mv package node_modules/tinyglobby/node_modules/picomatch && \
     rm picomatch-4.0.4.tgz
 
 # Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
@@ -125,9 +125,9 @@ RUN cd /usr/local/lib/node_modules/npm && \
 # Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
 RUN cd /usr/local/lib/node_modules/npm && \
     npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/picomatch && \
+    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
     tar -xzf picomatch-4.0.4.tgz && \
-    mv package node_modules/picomatch && \
+    mv package node_modules/tinyglobby/node_modules/picomatch && \
     rm picomatch-4.0.4.tgz
 
 # Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
@@ -176,6 +176,6 @@ ENTRYPOINT ["node", "dist/cli.js"]
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"
 LABEL description="PostgreSQL MCP Server - AI-native PostgreSQL operations with 248 tools, 23 resources, 20 prompts"
-LABEL version="3.0.2"
+LABEL version="3.0.3"
 LABEL org.opencontainers.image.source="https://github.com/neverinfamous/postgres-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.neverinfamous/postgres-mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neverinfamous/postgres-mcp",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "mcpName": "io.github.neverinfamous/postgres-mcp",
   "description": "PostgreSQL MCP server with connection pooling, tool filtering, and full extension support",
   "type": "module",

--- a/releases/v3.0.3.md
+++ b/releases/v3.0.3.md
@@ -1,0 +1,6 @@
+# v3.0.3 - Nested Vulnerability Patch
+
+This patch resolves the remaining `picomatch` vulnerability flagged by Docker Scout, which persisted because the vulnerable package was deeply nested within a subdependency.
+
+### Security
+*   **Deep Patching for `picomatch`**: Updated the npm bundler patch in the Dockerfile (for both builder and production stages) to extract `picomatch@4.0.4` directly into `node_modules/tinyglobby/node_modules/picomatch`. The previous top-level patch failed to overwrite this nested dependency, leaving the image vulnerable to Docker Scout scans.

--- a/server.json
+++ b/server.json
@@ -3,19 +3,19 @@
   "name": "io.github.neverinfamous/postgres-mcp",
   "title": "PostgreSQL MCP Server",
   "description": "PostgreSQL MCP server with connection pooling, tool filtering, and full extension support",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@neverinfamous/postgres-mcp",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.2",
+      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/adapters/postgresql/tools/__tests__/introspection.test.ts
+++ b/src/adapters/postgresql/tools/__tests__/introspection.test.ts
@@ -2337,7 +2337,7 @@ describe("pg_migration_rollback — uncovered branches", () => {
       rows: [
         {
           id: 3,
-          version: "3.0.2",
+          version: "3.0.3",
           status: "applied",
           rollback_sql: "DROP TABLE foo CASCADE",
           applied_at: "2026-01-01",


### PR DESCRIPTION
# v3.0.3 - Nested Vulnerability Patch

This patch resolves the remaining `picomatch` vulnerability flagged by Docker Scout, which persisted because the vulnerable package was deeply nested within a subdependency.

### Security
*   **Deep Patching for `picomatch`**: Updated the npm bundler patch in the Dockerfile (for both builder and production stages) to extract `picomatch@4.0.4` directly into `node_modules/tinyglobby/node_modules/picomatch`. The previous top-level patch failed to overwrite this nested dependency, leaving the image vulnerable to Docker Scout scans.
