### PR TITLE
v3.0.4 - Defensive Build Pathing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
 # Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
 RUN cd /usr/local/lib/node_modules/npm && \
     npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
+    mkdir -p node_modules/picomatch && \
+    mkdir -p node_modules/tinyglobby/node_modules/picomatch && \
     tar -xzf picomatch-4.0.4.tgz && \
-    mv package node_modules/tinyglobby/node_modules/picomatch && \
-    rm picomatch-4.0.4.tgz
+    rm -rf node_modules/picomatch/* node_modules/tinyglobby/node_modules/picomatch/* && \
+    cp -r package/* node_modules/picomatch/ && \
+    cp -r package/* node_modules/tinyglobby/node_modules/picomatch/ && \
+    rm -rf package picomatch-4.0.4.tgz
 
 # Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
 RUN cd /usr/local/lib/node_modules/npm && \
@@ -125,10 +128,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
 # Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
 RUN cd /usr/local/lib/node_modules/npm && \
     npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
+    mkdir -p node_modules/picomatch && \
+    mkdir -p node_modules/tinyglobby/node_modules/picomatch && \
     tar -xzf picomatch-4.0.4.tgz && \
-    mv package node_modules/tinyglobby/node_modules/picomatch && \
-    rm picomatch-4.0.4.tgz
+    rm -rf node_modules/picomatch/* node_modules/tinyglobby/node_modules/picomatch/* && \
+    cp -r package/* node_modules/picomatch/ && \
+    cp -r package/* node_modules/tinyglobby/node_modules/picomatch/ && \
+    rm -rf package picomatch-4.0.4.tgz
 
 # Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
 RUN cd /usr/local/lib/node_modules/npm && \
@@ -176,6 +182,6 @@ ENTRYPOINT ["node", "dist/cli.js"]
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"
 LABEL description="PostgreSQL MCP Server - AI-native PostgreSQL operations with 248 tools, 23 resources, 20 prompts"
-LABEL version="3.0.3"
+LABEL version="3.0.4"
 LABEL org.opencontainers.image.source="https://github.com/neverinfamous/postgres-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.neverinfamous/postgres-mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neverinfamous/postgres-mcp",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "mcpName": "io.github.neverinfamous/postgres-mcp",
   "description": "PostgreSQL MCP server with connection pooling, tool filtering, and full extension support",
   "type": "module",

--- a/releases/v3.0.4.md
+++ b/releases/v3.0.4.md
@@ -1,0 +1,6 @@
+# v3.0.4 - Defensive Build Pathing
+
+This patch explicitly fortifies the multi-stage Docker build process against upstream NPM restructuring logic.
+
+### Resiliency 
+*   **Defensive NPM Cache Patching**: Updated the `Dockerfile` to create parent directories prior to injecting patched `picomatch@4.0.4` assets. This ensures the Docker build doesn't break if `npm@latest` arbitrarily flattens or restructures its dependency tree (`lib/node_modules/npm/...`) on any given build. Unpacked assets are now consistently copied into both root and nested paths unconditionally.

--- a/server.json
+++ b/server.json
@@ -3,19 +3,19 @@
   "name": "io.github.neverinfamous/postgres-mcp",
   "title": "PostgreSQL MCP Server",
   "description": "PostgreSQL MCP server with connection pooling, tool filtering, and full extension support",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@neverinfamous/postgres-mcp",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.3",
+      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.4",
       "transport": {
         "type": "stdio"
       }

--- a/src/adapters/postgresql/tools/__tests__/introspection.test.ts
+++ b/src/adapters/postgresql/tools/__tests__/introspection.test.ts
@@ -2337,7 +2337,7 @@ describe("pg_migration_rollback — uncovered branches", () => {
       rows: [
         {
           id: 3,
-          version: "3.0.3",
+          version: "3.0.4",
           status: "applied",
           rollback_sql: "DROP TABLE foo CASCADE",
           applied_at: "2026-01-01",


### PR DESCRIPTION
# v3.0.4 - Defensive Build Pathing

This patch explicitly fortifies the multi-stage Docker build process against upstream NPM restructuring logic.

### Resiliency 
*   **Defensive NPM Cache Patching**: Updated the `Dockerfile` to create parent directories prior to injecting patched `picomatch@4.0.4` assets. This ensures the Docker build doesn't break if `npm@latest` arbitrarily flattens or restructures its dependency tree (`lib/node_modules/npm/...`) on any given build. Unpacked assets are now consistently copied into both root and nested paths unconditionally.
