### PR TITLE
v3.0.6 - KCache and Anomaly Detection Patch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -83,6 +83,7 @@ playwright.config.ts
 playwright-report/
 test-results/
 scripts/
+!scripts/patch-npm-deps.sh
 
 # Logs
 *.log

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -298,7 +298,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ${{ env.IMAGE_NAME }}
           readme-filepath: ./DOCKER_README.md
-          short-description: "PostgreSQL MCP: 248 Tools Via One Code Mode Tool with Tool Filtering, Pooling, HTTP/SSE & OAuth 2.1."
+          short-description: "PostgreSQL MCP: 248 Tools in 1 Code Mode, Audit+Token Log, Tool Filtering, Pooling, HTTP/SSE, OAuth"
 
       - name: Deployment Summary
         if: github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See [UNRELEASED.md](UNRELEASED.md) for all pending changes.
 - Playwright E2E test coverage for Code Mode, authentication, and backups.
 - Parameter extensions and aliases for core tools (e.g., `toType`, `indexName`).
 - Agent-optimized documentation and Code Mode integration guides.
+- **`pg_transaction_status` tool** — New read-only tool in the `transactions` group that checks the state of an active managed transaction without modifying it. Returns status (`"active"`, `"aborted"`, `"not_found"`). Exposed in Code Mode as `pg.transactions.status()`. Transaction tools: 7 → 8.
 
 ### Changed
 
@@ -31,6 +32,10 @@ See [UNRELEASED.md](UNRELEASED.md) for all pending changes.
 - Applied `openWorldHint: false` to all tools.
 - Centralized default connection pool timeout to 30,000ms.
 - Switched to SWC compilation for Vitest and reduced npm package size by excluding test/source map artifacts.
+- **Dependency Updates**
+  - `jose`: 6.2.0 → 6.2.1
+  - Dockerfile: bumped npm-bundled `tar` patch from 7.5.10 → 7.5.11 and `minimatch` to 10.2.4
+  - `package.json` overrides: exactly pinned `tar` to 7.5.11 and `minimatch` to 10.2.4
 
 ### Removed
 
@@ -51,29 +56,6 @@ See [UNRELEASED.md](UNRELEASED.md) for all pending changes.
 - Improved resilience in Admin and Monitoring tools when handling missing tables or extensions.
 - Bypassed Docker Hub rate-limit blocks in CI using authenticated pulls.
 - Resolved various logic regressions in cascade simulators, progress logging, and snake_case alias parsing.
-
-### Security
-
-- Patched prototype pollution vulnerabilities in `hono`.
-- Replaced raw exceptions with `PostgresMcpError` to prevent SQL syntax leaks.
-- Enforced SLSA Build L3 compliance via `--provenance` in publishing workflows.
-- Patched vulnerabilities in Docker builds.
-- Added `push` trigger to `secrets-scanning.yml` for early leak detection on feature branches.
-- Cleaned `.trivyignore` to contain only CVE IDs (removed inert path entries).
-
-### Added
-
-- **`pg_transaction_status` tool** — New read-only tool in the `transactions` group that checks the state of an active managed transaction without modifying it. Returns status (`"active"`, `"aborted"`, `"not_found"`). Exposed in Code Mode as `pg.transactions.status()`. Transaction tools: 7 → 8.
-
-### Changed
-
-- **Dependency Updates**
-  - `jose`: 6.2.0 → 6.2.1
-  - Dockerfile: bumped npm-bundled `tar` patch from 7.5.10 → 7.5.11 and `minimatch` to 10.2.4
-  - `package.json` overrides: exactly pinned `tar` to 7.5.11 and `minimatch` to 10.2.4
-
-### Fixed
-
 - **Introspection Tools Silent Empty Results** — `pg_dependency_graph`, `pg_topological_sort`, `pg_constraint_analysis`, and `pg_cascade_simulator` now explicitly return a structured error (`success: false`) when queried against nonexistent schemas or tables instead of silently returning empty findings.
 - **Migration Record Status** — `pg_migration_record` now inserts entries with `status: 'recorded'` instead of defaulting to `'applied'`, distinguishing metadata-only records from executed migrations.
 - **Anomaly Detection Tools Numeric Coercion** — `pg_detect_query_anomalies`, `pg_detect_bloat_risk`, and `pg_detect_connection_spike` now gracefully fall back to default values for non-numeric parameter inputs instead of producing raw framework output validation errors.
@@ -83,6 +65,12 @@ See [UNRELEASED.md](UNRELEASED.md) for all pending changes.
 
 ### Security
 
+- Patched prototype pollution vulnerabilities in `hono`.
+- Replaced raw exceptions with `PostgresMcpError` to prevent SQL syntax leaks.
+- Enforced SLSA Build L3 compliance via `--provenance` in publishing workflows.
+- Patched vulnerabilities in Docker builds.
+- Added `push` trigger to `secrets-scanning.yml` for early leak detection on feature branches.
+- Cleaned `.trivyignore` to contain only CVE IDs (removed inert path entries).
 - **Schema Validation** — Mitigated an SQL injection risk in diagnostics and anomaly-detection modules by replacing ad-hoc string escaping with `validateIdentifier()` schema validation.
 
 ## [2.2.0] - 2026-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/neverinfamous/postgres-mcp/compare/v3.0.0...HEAD)
+## [Unreleased](https://github.com/neverinfamous/postgres-mcp/compare/v3.0.6...HEAD)
 
 See [UNRELEASED.md](UNRELEASED.md) for all pending changes.
+
+## [3.0.6](https://github.com/neverinfamous/postgres-mcp/releases/tag/v3.0.6) - 2026-04-08
+
+### Security
+
+- **hono**: Pinned to `4.12.12` to address moderate vulnerabilities including path traversal and middleware bypass.
+
+### Changed
+
+- **Dependencies**: Bumped `@vitest/coverage-v8`, `typescript-eslint`, and `vitest`.
+- **Dockerfile**: Extracted duplicated CVE patch instructions into `scripts/patch-npm-deps.sh` to eliminate stage drift and enforce cache purging.
+
+### Fixed
+
+- **anomaly-detection**: Modified `pg_detect_bloat_risk` to return empty responses instead of validation errors on nonexistent schemas.
+- **caching**: Added robust validation for `METADATA_CACHE_TTL_MS` to prevent cache expiration failures.
+- **core**: Removed `.unknown()` from column type schemas to constrain default values and prevent DDL validation errors.
+- **kcache**: Ensured `query_preview` remains preserved during compact payload generation across CPU, IO, and query tools.
+- **kcache**: Increased API parameter bounds from 10 to 100 and improved property aliasing.
+- **kcache**: Added `coerceNumber` data preprocessing to all numeric thresholds to properly handle string inputs.
+- **partitioning**: Patched syntax errors by escaping embedded single quotes within DDL fragment values.
 
 ## [3.0.0](https://github.com/neverinfamous/postgres-mcp/releases/tag/v3.0.0) - 2026-04-05
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,8 @@
 # postgres-mcp
 
-**PostgreSQL MCP Server** enabling AI assistants to securely interact with PostgreSQL databases through the Model Context Protocol. Features **Code Mode** — a revolutionary approach that provides access to all 248 tools through a secure, true V8 isolate (`worker_threads`), eliminating the massive token overhead of multi-step tool calls. Also includes schema introspection, migration tracking, smart tool filtering, deterministic error handling, connection pooling, HTTP/SSE transport, OAuth 2.1 authentication, and support for citext, ltree, pgcrypto, pg_cron, pg_stat_kcache, pgvector, PostGIS, and HypoPG.
+**PostgreSQL MCP Server** binding the Model Context Protocol to a secure PostgreSQL sandbox.
+
+Features **Code Mode** — a revolutionary approach that provides access to all 248 tools through a secure, true V8 isolate (`worker_threads`), eliminating the massive token overhead of multi-step tool calls. Also includes schema introspection, migration tracking, smart tool filtering, deterministic error handling, connection pooling, HTTP/SSE transport, OAuth 2.1 authentication, and support for citext, ltree, pgcrypto, pg_cron, pg_stat_kcache, pgvector, PostGIS, and HypoPG.
 
 **248 Specialized Tools** · **23 Resources** · **20 AI-Powered Prompts**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,57 +12,9 @@ RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/m
 # Upgrade npm globally to get fixed versions of bundled packages
 RUN npm install -g npm@latest --force && npm cache clean --force
 
-# Fix GHSA-73rr-hh4g-fpgx: Manually update npm's bundled diff to 8.0.4
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack diff@8.0.4 && \
-    rm -rf node_modules/diff && \
-    tar -xzf diff-8.0.4.tgz && \
-    mv package node_modules/diff && \
-    rm diff-8.0.4.tgz
-
-# Fix CVE-2026-25547: Manually update npm's bundled @isaacs/brace-expansion@5.0.0 to 5.0.1
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack @isaacs/brace-expansion@5.0.1 && \
-    rm -rf node_modules/@isaacs/brace-expansion && \
-    mkdir -p node_modules/@isaacs/brace-expansion && \
-    tar -xzf isaacs-brace-expansion-5.0.1.tgz && \
-    mv package/* node_modules/@isaacs/brace-expansion/ && \
-    rm -rf package isaacs-brace-expansion-5.0.1.tgz
-
-# Fix CVE-2026-23950, CVE-2026-24842: Manually update npm's bundled tar to 7.5.13
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.13 && \
-    rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.13.tgz && \
-    mv package node_modules/tar && \
-    rm tar-7.5.13.tgz
-
-# Fix CVE-2026-27904, CVE-2026-27903: Manually update npm's bundled minimatch to 10.2.5
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack minimatch@10.2.5 && \
-    rm -rf node_modules/minimatch && \
-    tar -xzf minimatch-10.2.5.tgz && \
-    mv package node_modules/minimatch && \
-    rm minimatch-10.2.5.tgz
-
-# Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/picomatch && \
-    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
-    tar -xzf picomatch-4.0.4.tgz && \
-    cp -a package node_modules/picomatch && \
-    mkdir -p node_modules/tinyglobby/node_modules && \
-    cp -a package node_modules/tinyglobby/node_modules/picomatch && \
-    rm -rf package picomatch-4.0.4.tgz
-
-# Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack brace-expansion@5.0.5 && \
-    rm -rf node_modules/brace-expansion && \
-    tar -xzf brace-expansion-5.0.5.tgz && \
-    mv package node_modules/brace-expansion && \
-    rm brace-expansion-5.0.5.tgz
+# Patch npm's bundled dependencies for known CVEs (shared script — single source of truth)
+COPY scripts/patch-npm-deps.sh ./scripts/
+RUN sh scripts/patch-npm-deps.sh
 
 
 # Copy package files first for better layer caching
@@ -92,58 +44,9 @@ RUN apk add --no-cache ca-certificates && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main 'zlib>=1.3.2-r0' && \
     npm install -g npm@latest --force && npm cache clean --force
 
-# Fix GHSA-73rr-hh4g-fpgx: Manually update npm's bundled diff to 8.0.4
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack diff@8.0.4 && \
-    rm -rf node_modules/diff && \
-    tar -xzf diff-8.0.4.tgz && \
-    mv package node_modules/diff && \
-    rm diff-8.0.4.tgz
-
-# Fix CVE-2026-25547: Manually update npm's bundled @isaacs/brace-expansion@5.0.0 to 5.0.1
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack @isaacs/brace-expansion@5.0.1 && \
-    rm -rf node_modules/@isaacs/brace-expansion && \
-    mkdir -p node_modules/@isaacs/brace-expansion && \
-    tar -xzf isaacs-brace-expansion-5.0.1.tgz && \
-    mv package/* node_modules/@isaacs/brace-expansion/ && \
-    rm -rf package isaacs-brace-expansion-5.0.1.tgz
-
-# Fix CVE-2026-23950, CVE-2026-24842: Manually update npm's bundled tar to 7.5.13
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.13 && \
-    rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.13.tgz && \
-    mv package node_modules/tar && \
-    rm tar-7.5.13.tgz
-
-# Fix CVE-2026-27904, CVE-2026-27903: Manually update npm's bundled minimatch to 10.2.5
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack minimatch@10.2.5 && \
-    rm -rf node_modules/minimatch && \
-    tar -xzf minimatch-10.2.5.tgz && \
-    mv package node_modules/minimatch && \
-    rm minimatch-10.2.5.tgz
-
-# Fix CVE-2026-33671, CVE-2026-33672: Manually update npm's bundled picomatch to 4.0.4
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack picomatch@4.0.4 && \
-    rm -rf node_modules/picomatch && \
-    rm -rf node_modules/tinyglobby/node_modules/picomatch && \
-    tar -xzf picomatch-4.0.4.tgz && \
-    cp -a package node_modules/picomatch && \
-    mkdir -p node_modules/tinyglobby/node_modules && \
-    cp -a package node_modules/tinyglobby/node_modules/picomatch && \
-    rm -rf package picomatch-4.0.4.tgz
-
-# Fix CVE-2026-33750: Manually update npm's bundled brace-expansion to 5.0.5
-RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack brace-expansion@5.0.5 && \
-    rm -rf node_modules/brace-expansion && \
-    tar -xzf brace-expansion-5.0.5.tgz && \
-    mv package node_modules/brace-expansion && \
-    rm brace-expansion-5.0.5.tgz
-
+# Patch npm's bundled dependencies for known CVEs (with cache cleanup for lean image)
+COPY scripts/patch-npm-deps.sh ./scripts/
+RUN sh scripts/patch-npm-deps.sh --clean-cache
 
 # Copy built artifacts and production dependencies
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <!-- mcp-name: io.github.neverinfamous/postgres-mcp -->
 
-**PostgreSQL MCP Server** enabling AI assistants to interact with PostgreSQL databases through the Model Context Protocol. Features **Code Mode** — a revolutionary approach that provides access to all 248 tools through a secure, true V8 isolate (`worker_threads`), eliminating the massive token overhead of multi-step tool calls. Also includes schema introspection, migration tracking, smart tool filtering, deterministic error handling, connection pooling, HTTP/SSE Transport, OAuth 2.1 authentication, and extension support for citext, ltree, pgcrypto, pg_cron, pg_stat_kcache, pgvector, PostGIS, and HypoPG.
+**PostgreSQL MCP Server** binding the Model Context Protocol to a secure PostgreSQL sandbox.
+
+Features **Code Mode** — a revolutionary approach that provides access to all 248 tools through a secure, true V8 isolate (`worker_threads`), eliminating the massive token overhead of multi-step tool calls. Also includes schema introspection, migration tracking, smart tool filtering, deterministic error handling, connection pooling, HTTP/SSE Transport, OAuth 2.1 authentication, and extension support for citext, ltree, pgcrypto, pg_cron, pg_stat_kcache, pgvector, PostGIS, and HypoPG.
 
 **248 Specialized Tools** · **23 Resources** · **20 AI-Powered Prompts**
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,20 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **hono**: Pinned to `4.12.12` to address moderate vulnerabilities including path traversal and middleware bypass.
 
-- **hono**: Pinned override to `4.12.12` to address multiple moderate severity vulnerabilities (cookie write path validation, path traversal in `toSSG()`, middleware bypass in `serveStatic()`, etc.)
-
+### Changed
+- **Dependencies**: Bumped `@vitest/coverage-v8`, `typescript-eslint`, and `vitest`.
+- **Dockerfile**: Extracted duplicated CVE patch instructions into `scripts/patch-npm-deps.sh` to eliminate stage drift and enforce cache purging.
 
 ### Fixed
-
-- **kcache output optimization**: Ensured `query_preview` is preserved in the response even when `compact` mode is active across `pg_kcache_query_stats`, `pg_kcache_top_cpu`, `pg_kcache_top_io`, and `pg_kcache_resource_analysis` to maintain query debuggability while saving tokens
-- **Anomaly Detection Empty Filters**: `pg_detect_bloat_risk` now properly returns an empty array and `totalAnalyzed: 0` instead of throwing a validation error when queried with a nonexistent schema
-- **kcache schemas**: Apply `coerceNumber` preprocess to all numeric params (`limit`, `minCalls`, `queryPreviewLength`, `threshold`) — string inputs like `"5"` are now properly coerced instead of rejected
-- **partition preprocessing**: Escape embedded single quotes in `from`/`to`/`values[]` when building `forValues` DDL fragments — prevents broken SQL and potential injection
-- **adapter-cache**: Validate `METADATA_CACHE_TTL_MS` env var with `Number.isFinite()` fallback — prevents `NaN` from silently disabling TTL expiry
-- **core queries**: Remove `.unknown()` from `default`/`defaultValue` column schema — restores constrained `string|number|boolean` union to prevent objects from generating invalid DDL
-- **Core Verification**: Completed advanced Code Mode stress testing across all 20 core tools. Confirmed 100% boundary value resilience, idempotency integrity, object existence patterns, and Zod parameter consistency.
-### Changed
-
-- **Dockerfile**: Extract 6 duplicated CVE patch `RUN` blocks into shared `scripts/patch-npm-deps.sh` — eliminates drift between builder and production stages; production stage now includes `--clean-cache` to purge `/root/.npm`
-- **Dependency Updates**: Updated `@vitest/coverage-v8` to `4.1.3`, `typescript-eslint` from `8.58.0` to `8.58.1`, `vitest` to `4.1.3`.
+- **anomaly-detection**: Modified `pg_detect_bloat_risk` to return empty responses instead of validation errors on nonexistent schemas.
+- **caching**: Added robust validation for `METADATA_CACHE_TTL_MS` to prevent cache expiration failures.
+- **core**: Removed `.unknown()` from column type schemas to constrain default values and prevent DDL validation errors.
+- **kcache**: Ensured `query_preview` remains preserved during compact payload generation across CPU, IO, and query tools.
+- **kcache**: Increased API parameter bounds from 10 to 100 and improved property aliasing.
+- **kcache**: Added `coerceNumber` data preprocessing to all numeric thresholds to properly handle string inputs.
+- **partitioning**: Patched syntax errors by escaping embedded single quotes within DDL fragment values.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,3 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- **kcache schemas**: Apply `coerceNumber` preprocess to all numeric params (`limit`, `minCalls`, `queryPreviewLength`, `threshold`) — string inputs like `"5"` are now properly coerced instead of rejected
+- **partition preprocessing**: Escape embedded single quotes in `from`/`to`/`values[]` when building `forValues` DDL fragments — prevents broken SQL and potential injection
+- **adapter-cache**: Validate `METADATA_CACHE_TTL_MS` env var with `Number.isFinite()` fallback — prevents `NaN` from silently disabling TTL expiry
+- **core queries**: Remove `.unknown()` from `default`/`defaultValue` column schema — restores constrained `string|number|boolean` union to prevent objects from generating invalid DDL
+
+### Changed
+
+- **Dockerfile**: Extract 6 duplicated CVE patch `RUN` blocks into shared `scripts/patch-npm-deps.sh` — eliminates drift between builder and production stages; production stage now includes `--clean-cache` to purge `/root/.npm`

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **kcache output optimization**: Ensured `query_preview` is preserved in the response even when `compact` mode is active across `pg_kcache_query_stats`, `pg_kcache_top_cpu`, `pg_kcache_top_io`, and `pg_kcache_resource_analysis` to maintain query debuggability while saving tokens
 - **Anomaly Detection Empty Filters**: `pg_detect_bloat_risk` now properly returns an empty array and `totalAnalyzed: 0` instead of throwing a validation error when queried with a nonexistent schema
 - **kcache schemas**: Apply `coerceNumber` preprocess to all numeric params (`limit`, `minCalls`, `queryPreviewLength`, `threshold`) — string inputs like `"5"` are now properly coerced instead of rejected
 - **partition preprocessing**: Escape embedded single quotes in `from`/`to`/`values[]` when building `forValues` DDL fragments — prevents broken SQL and potential injection

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,19 +6,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Security
-- **hono**: Pinned to `4.12.12` to address moderate vulnerabilities including path traversal and middleware bypass.
-
-### Changed
-- **Dependencies**: Bumped `@vitest/coverage-v8`, `typescript-eslint`, and `vitest`.
-- **Dockerfile**: Extracted duplicated CVE patch instructions into `scripts/patch-npm-deps.sh` to eliminate stage drift and enforce cache purging.
-
-### Fixed
-- **anomaly-detection**: Modified `pg_detect_bloat_risk` to return empty responses instead of validation errors on nonexistent schemas.
-- **caching**: Added robust validation for `METADATA_CACHE_TTL_MS` to prevent cache expiration failures.
-- **core**: Removed `.unknown()` from column type schemas to constrain default values and prevent DDL validation errors.
-- **kcache**: Ensured `query_preview` remains preserved during compact payload generation across CPU, IO, and query tools.
-- **kcache**: Increased API parameter bounds from 10 to 100 and improved property aliasing.
-- **kcache**: Added `coerceNumber` data preprocessing to all numeric thresholds to properly handle string inputs.
-- **partitioning**: Patched syntax errors by escaping embedded single quotes within DDL fragment values.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **partition preprocessing**: Escape embedded single quotes in `from`/`to`/`values[]` when building `forValues` DDL fragments — prevents broken SQL and potential injection
 - **adapter-cache**: Validate `METADATA_CACHE_TTL_MS` env var with `Number.isFinite()` fallback — prevents `NaN` from silently disabling TTL expiry
 - **core queries**: Remove `.unknown()` from `default`/`defaultValue` column schema — restores constrained `string|number|boolean` union to prevent objects from generating invalid DDL
-
+- **Core Verification**: Completed advanced Code Mode stress testing across all 20 core tools. Confirmed 100% boundary value resilience, idempotency integrity, object existence patterns, and Zod parameter consistency.
 ### Changed
 
 - **Dockerfile**: Extract 6 duplicated CVE patch `RUN` blocks into shared `scripts/patch-npm-deps.sh` — eliminates drift between builder and production stages; production stage now includes `--clean-cache` to purge `/root/.npm`

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Anomaly Detection Empty Filters**: `pg_detect_bloat_risk` now properly returns an empty array and `totalAnalyzed: 0` instead of throwing a validation error when queried with a nonexistent schema
 - **kcache schemas**: Apply `coerceNumber` preprocess to all numeric params (`limit`, `minCalls`, `queryPreviewLength`, `threshold`) — string inputs like `"5"` are now properly coerced instead of rejected
 - **partition preprocessing**: Escape embedded single quotes in `from`/`to`/`values[]` when building `forValues` DDL fragments — prevents broken SQL and potential injection
 - **adapter-cache**: Validate `METADATA_CACHE_TTL_MS` env var with `Number.isFinite()` fallback — prevents `NaN` from silently disabling TTL expiry

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **hono**: Pinned override to `4.12.12` to address multiple moderate severity vulnerabilities (cookie write path validation, path traversal in `toSSG()`, middleware bypass in `serveStatic()`, etc.)
+
+
 ### Fixed
 
 - **kcache output optimization**: Ensured `query_preview` is preserved in the response even when `compact` mode is active across `pg_kcache_query_stats`, `pg_kcache_top_cpu`, `pg_kcache_top_io`, and `pg_kcache_resource_analysis` to maintain query debuggability while saving tokens
@@ -19,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Dockerfile**: Extract 6 duplicated CVE patch `RUN` blocks into shared `scripts/patch-npm-deps.sh` — eliminates drift between builder and production stages; production stage now includes `--clean-cache` to purge `/root/.npm`
+- **Dependency Updates**: Updated `@vitest/coverage-v8` to `4.1.3`, `typescript-eslint` from `8.58.0` to `8.58.1`, `vitest` to `4.1.3`.

--- a/mcp-config-example.json
+++ b/mcp-config-example.json
@@ -19,6 +19,10 @@
         "-e",
         "POSTGRES_URL",
         "-e",
+        "POSTGRES_TOOL_FILTER",
+        "-e",
+        "LOG_LEVEL",
+        "-e",
         "MCP_AUTH_TOKEN",
         "-e",
         "OAUTH_ENABLED",
@@ -26,6 +30,10 @@
         "OAUTH_ISSUER",
         "-e",
         "OAUTH_AUDIENCE",
+        "-e",
+        "AUDIT_BACKUP",
+        "-e",
+        "AUDIT_REDACT",
         "writenotenow/postgres-mcp:latest",
         "--tool-filter",
         "codemode",
@@ -39,10 +47,14 @@
         "POSTGRES_PASSWORD": "your_password",
         "POSTGRES_DATABASE": "your_database",
         "POSTGRES_URL": "postgres://user:pass@host.docker.internal:5432/db",
+        "POSTGRES_TOOL_FILTER": "",
+        "LOG_LEVEL": "info",
         "MCP_AUTH_TOKEN": "",
         "OAUTH_ENABLED": "false",
         "OAUTH_ISSUER": "",
-        "OAUTH_AUDIENCE": ""
+        "OAUTH_AUDIENCE": "",
+        "AUDIT_BACKUP": "false",
+        "AUDIT_REDACT": "false"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neverinfamous/postgres-mcp",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,38 +96,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -175,13 +172,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
-      "integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.4",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -190,22 +187,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
-      "integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -237,9 +234,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
-      "integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -247,13 +244,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
-      "integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -261,9 +258,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -415,9 +412,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -434,9 +431,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -460,9 +457,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -477,9 +474,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -494,9 +491,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -511,9 +508,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -528,9 +525,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -545,9 +542,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +562,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
@@ -585,9 +582,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
@@ -605,9 +602,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
@@ -625,9 +622,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
@@ -645,9 +642,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
@@ -665,9 +662,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -682,9 +679,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -692,16 +689,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -716,9 +715,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -733,9 +732,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -777,16 +776,16 @@
       "license": "MIT"
     },
     "node_modules/@swc/core": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
-      "integrity": "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.24.tgz",
+      "integrity": "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.25"
+        "@swc/types": "^0.1.26"
       },
       "engines": {
         "node": ">=10"
@@ -796,18 +795,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.21",
-        "@swc/core-darwin-x64": "1.15.21",
-        "@swc/core-linux-arm-gnueabihf": "1.15.21",
-        "@swc/core-linux-arm64-gnu": "1.15.21",
-        "@swc/core-linux-arm64-musl": "1.15.21",
-        "@swc/core-linux-ppc64-gnu": "1.15.21",
-        "@swc/core-linux-s390x-gnu": "1.15.21",
-        "@swc/core-linux-x64-gnu": "1.15.21",
-        "@swc/core-linux-x64-musl": "1.15.21",
-        "@swc/core-win32-arm64-msvc": "1.15.21",
-        "@swc/core-win32-ia32-msvc": "1.15.21",
-        "@swc/core-win32-x64-msvc": "1.15.21"
+        "@swc/core-darwin-arm64": "1.15.24",
+        "@swc/core-darwin-x64": "1.15.24",
+        "@swc/core-linux-arm-gnueabihf": "1.15.24",
+        "@swc/core-linux-arm64-gnu": "1.15.24",
+        "@swc/core-linux-arm64-musl": "1.15.24",
+        "@swc/core-linux-ppc64-gnu": "1.15.24",
+        "@swc/core-linux-s390x-gnu": "1.15.24",
+        "@swc/core-linux-x64-gnu": "1.15.24",
+        "@swc/core-linux-x64-musl": "1.15.24",
+        "@swc/core-win32-arm64-msvc": "1.15.24",
+        "@swc/core-win32-ia32-msvc": "1.15.24",
+        "@swc/core-win32-x64-msvc": "1.15.24"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -819,9 +818,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.21.tgz",
-      "integrity": "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.24.tgz",
+      "integrity": "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +836,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.21.tgz",
-      "integrity": "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.24.tgz",
+      "integrity": "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg==",
       "cpu": [
         "x64"
       ],
@@ -855,9 +854,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.21.tgz",
-      "integrity": "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.24.tgz",
+      "integrity": "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw==",
       "cpu": [
         "arm"
       ],
@@ -873,9 +872,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.21.tgz",
-      "integrity": "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.24.tgz",
+      "integrity": "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA==",
       "cpu": [
         "arm64"
       ],
@@ -894,9 +893,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.21.tgz",
-      "integrity": "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.24.tgz",
+      "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
       "cpu": [
         "arm64"
       ],
@@ -915,9 +914,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.21.tgz",
-      "integrity": "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.24.tgz",
+      "integrity": "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ==",
       "cpu": [
         "ppc64"
       ],
@@ -936,9 +935,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.21.tgz",
-      "integrity": "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.24.tgz",
+      "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
       "cpu": [
         "s390x"
       ],
@@ -957,9 +956,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.21.tgz",
-      "integrity": "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.24.tgz",
+      "integrity": "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw==",
       "cpu": [
         "x64"
       ],
@@ -978,9 +977,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.21.tgz",
-      "integrity": "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.24.tgz",
+      "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
       "cpu": [
         "x64"
       ],
@@ -999,9 +998,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.21.tgz",
-      "integrity": "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.24.tgz",
+      "integrity": "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA==",
       "cpu": [
         "arm64"
       ],
@@ -1017,9 +1016,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.21.tgz",
-      "integrity": "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.24.tgz",
+      "integrity": "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ==",
       "cpu": [
         "ia32"
       ],
@@ -1035,9 +1034,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.21",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.21.tgz",
-      "integrity": "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==",
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.24.tgz",
+      "integrity": "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ==",
       "cpu": [
         "x64"
       ],
@@ -1144,17 +1143,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/type-utils": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1167,7 +1166,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1183,16 +1182,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1208,14 +1207,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1230,14 +1229,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1248,9 +1247,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1265,15 +1264,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1290,9 +1289,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1304,16 +1303,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1332,16 +1331,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1356,13 +1355,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.58.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1374,14 +1373,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
-      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.3.tgz",
+      "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.3",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1395,8 +1394,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.2",
-        "vitest": "4.1.2"
+        "@vitest/browser": "4.1.3",
+        "vitest": "4.1.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1405,16 +1404,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
+      "integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1423,13 +1422,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
+      "integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1450,9 +1449,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
+      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1463,13 +1462,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
+      "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1477,14 +1476,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
+      "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1493,9 +1492,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
+      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1503,13 +1502,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
+      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.3",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1713,9 +1712,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2483,9 +2482,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3466,9 +3465,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -3567,9 +3566,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3615,14 +3614,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3631,21 +3630,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
     },
     "node_modules/router": {
@@ -3775,13 +3774,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3897,9 +3896,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3907,14 +3906,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4005,16 +4004,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.0",
-        "@typescript-eslint/parser": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0"
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4095,16 +4094,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.13",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -4122,7 +4121,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -4188,19 +4187,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
+      "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.3",
+        "@vitest/mocker": "4.1.3",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/runner": "4.1.3",
+        "@vitest/snapshot": "4.1.3",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4228,10 +4227,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.3",
+        "@vitest/browser-preview": "4.1.3",
+        "@vitest/browser-webdriverio": "4.1.3",
+        "@vitest/coverage-istanbul": "4.1.3",
+        "@vitest/coverage-v8": "4.1.3",
+        "@vitest/ui": "4.1.3",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4253,6 +4254,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neverinfamous/postgres-mcp",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "mcpName": "io.github.neverinfamous/postgres-mcp",
   "description": "PostgreSQL MCP server with connection pooling, tool filtering, and full extension support",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@isaacs/brace-expansion": "5.0.1",
     "diff": "8.0.4",
     "flatted": "3.4.2",
-    "hono": "4.12.10",
+    "hono": "4.12.12",
     "minimatch": "10.2.5",
     "picomatch": "4.0.4",
     "tar": "7.5.13"

--- a/releases/v3.0.6.md
+++ b/releases/v3.0.6.md
@@ -1,0 +1,34 @@
+# v3.0.6 - KCache and Anomaly Detection Patch
+
+### Highlights
+
+- **KCache Optimization**: Ensured `query_preview` preservation and increased API bounds.
+- **Security Hardening**: Pinned `hono` to `4.12.12` to mitigate middleware vulnerabilities.
+- **Core Stability**: Constrained DDL validations and improved anomaly detection edge cases.
+
+### Security
+
+- **hono**: Pinned to `4.12.12` to address moderate vulnerabilities including path traversal and middleware bypass.
+
+### Changed
+
+- **Dependencies**: Bumped `@vitest/coverage-v8`, `typescript-eslint`, and `vitest`.
+- **Dockerfile**: Extracted duplicated CVE patch instructions into `scripts/patch-npm-deps.sh` to eliminate stage drift and enforce cache purging.
+
+### Fixed
+
+- **anomaly-detection**: Modified `pg_detect_bloat_risk` to return empty responses instead of validation errors on nonexistent schemas.
+- **caching**: Added robust validation for `METADATA_CACHE_TTL_MS` to prevent cache expiration failures.
+- **core**: Removed `.unknown()` from column type schemas to constrain default values and prevent DDL validation errors.
+- **kcache**: Ensured `query_preview` remains preserved during compact payload generation across CPU, IO, and query tools.
+- **kcache**: Increased API parameter bounds from 10 to 100 and improved property aliasing.
+- **kcache**: Added `coerceNumber` data preprocessing to all numeric thresholds to properly handle string inputs.
+- **partitioning**: Patched syntax errors by escaping embedded single quotes within DDL fragment values.
+
+---
+
+[Full Compare](https://github.com/neverinfamous/postgres-mcp/compare/v3.0.5...v3.0.6)
+
+```bash
+docker pull writenotenow/postgres-mcp:v3.0.6
+```

--- a/scripts/patch-npm-deps.sh
+++ b/scripts/patch-npm-deps.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# postgres-mcp — Patch npm bundled dependencies
+#
+# Single source of truth for all CVE-related npm bundled dependency patches.
+# Called from both builder and production stages to avoid drift.
+#
+# Usage: sh scripts/patch-npm-deps.sh [--clean-cache]
+#   --clean-cache  Also purge npm cache and /root/.npm after patching
+
+set -eu
+
+NPM_DIR=/usr/local/lib/node_modules/npm
+
+# Fix GHSA-73rr-hh4g-fpgx: diff → 8.0.4
+cd "$NPM_DIR"
+npm pack diff@8.0.4
+rm -rf node_modules/diff
+tar -xzf diff-8.0.4.tgz
+mv package node_modules/diff
+rm diff-8.0.4.tgz
+
+# Fix CVE-2026-25547: @isaacs/brace-expansion → 5.0.1
+cd "$NPM_DIR"
+npm pack @isaacs/brace-expansion@5.0.1
+rm -rf node_modules/@isaacs/brace-expansion
+mkdir -p node_modules/@isaacs/brace-expansion
+tar -xzf isaacs-brace-expansion-5.0.1.tgz
+mv package/* node_modules/@isaacs/brace-expansion/
+rm -rf package isaacs-brace-expansion-5.0.1.tgz
+
+# Fix CVE-2026-23950, CVE-2026-24842: tar → 7.5.13
+cd "$NPM_DIR"
+npm pack tar@7.5.13
+rm -rf node_modules/tar
+tar -xzf tar-7.5.13.tgz
+mv package node_modules/tar
+rm tar-7.5.13.tgz
+
+# Fix CVE-2026-27904, CVE-2026-27903: minimatch → 10.2.5
+cd "$NPM_DIR"
+npm pack minimatch@10.2.5
+rm -rf node_modules/minimatch
+tar -xzf minimatch-10.2.5.tgz
+mv package node_modules/minimatch
+rm minimatch-10.2.5.tgz
+
+# Fix CVE-2026-33671, CVE-2026-33672: picomatch → 4.0.4 (top-level + nested in tinyglobby)
+cd "$NPM_DIR"
+npm pack picomatch@4.0.4
+rm -rf node_modules/picomatch
+rm -rf node_modules/tinyglobby/node_modules/picomatch
+tar -xzf picomatch-4.0.4.tgz
+cp -a package node_modules/picomatch
+mkdir -p node_modules/tinyglobby/node_modules
+cp -a package node_modules/tinyglobby/node_modules/picomatch
+rm -rf package picomatch-4.0.4.tgz
+
+# Fix CVE-2026-33750: brace-expansion → 5.0.5
+cd "$NPM_DIR"
+npm pack brace-expansion@5.0.5
+rm -rf node_modules/brace-expansion
+tar -xzf brace-expansion-5.0.5.tgz
+mv package node_modules/brace-expansion
+rm brace-expansion-5.0.5.tgz
+
+# Optional cache cleanup (used in production stage to keep image lean)
+if [ "${1:-}" = "--clean-cache" ]; then
+  npm cache clean --force
+  rm -rf /root/.npm
+fi

--- a/server.json
+++ b/server.json
@@ -8,14 +8,14 @@
     {
       "registryType": "npm",
       "identifier": "@neverinfamous/postgres-mcp",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.5",
+      "identifier": "docker.io/writenotenow/postgres-mcp:v3.0.6",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/benchmarks/tool-filtering.bench.ts
+++ b/src/__tests__/benchmarks/tool-filtering.bench.ts
@@ -13,10 +13,8 @@ import {
   getToolGroup,
   getFilterSummary,
   TOOL_GROUPS,
-  META_GROUPS,
 } from "../../filtering/tool-filter.js";
-import { getMetaGroupTools } from "../../filtering/tool-filter.js";
-import type { ToolGroup, MetaGroup } from "../../types/index.js";
+import type { ToolGroup } from "../../types/index.js";
 
 // Suppress logger output
 vi.mock("../../utils/logger.js", () => ({
@@ -145,15 +143,4 @@ describe("Filter Summary", () => {
     { iterations: 2000, warmupIterations: 20 },
   );
 
-  bench(
-    "getMetaGroupInfo() catalog (inline)",
-    () => {
-      Object.entries(META_GROUPS).map(([metaGroup, groups]) => ({
-        metaGroup: metaGroup as MetaGroup,
-        groups,
-        count: getMetaGroupTools(metaGroup as MetaGroup).length,
-      }));
-    },
-    { iterations: 2000, warmupIterations: 20 },
-  );
 });

--- a/src/adapters/postgresql/adapter-cache.ts
+++ b/src/adapters/postgresql/adapter-cache.ts
@@ -11,10 +11,13 @@
 /**
  * Default cache TTL in milliseconds (configurable via METADATA_CACHE_TTL_MS env var).
  */
-export const DEFAULT_CACHE_TTL_MS = parseInt(
+const parsedCacheTtlMs = parseInt(
   process.env["METADATA_CACHE_TTL_MS"] ?? "30000",
   10,
 );
+export const DEFAULT_CACHE_TTL_MS = Number.isFinite(parsedCacheTtlMs)
+  ? parsedCacheTtlMs
+  : 30000;
 
 /**
  * Metadata cache entry with TTL support.

--- a/src/adapters/postgresql/schemas/core/queries.ts
+++ b/src/adapters/postgresql/schemas/core/queries.ts
@@ -214,13 +214,13 @@ export const CreateTableSchemaBase = z.object({
         primaryKey: z.boolean().optional(),
         unique: z.boolean().optional(),
         default: z
-          .unknown()
+          .union([z.string(), z.number(), z.boolean()])
           .optional()
           .describe(
             "Default value (raw SQL expression). Numbers/booleans auto-coerced to string.",
           ),
         defaultValue: z
-          .unknown()
+          .union([z.string(), z.number(), z.boolean()])
           .optional()
           .describe(
             "Alias for default. Numbers/booleans auto-coerced to string.",
@@ -347,10 +347,7 @@ export const CreateTableSchema = z
       const rawDefault = col.default ?? col.defaultValue;
       let defaultValue: string | undefined;
       if (rawDefault !== undefined && rawDefault !== null) {
-        defaultValue =
-          typeof rawDefault === "object"
-            ? JSON.stringify(rawDefault)
-            : String(rawDefault as string | number | boolean);
+        defaultValue = String(rawDefault);
 
         // Auto-convert common function shortcuts to valid SQL expressions
         // e.g., now() → CURRENT_TIMESTAMP (PostgreSQL rejects now() as column reference)

--- a/src/adapters/postgresql/schemas/extensions/kcache.ts
+++ b/src/adapters/postgresql/schemas/extensions/kcache.ts
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 import { normalizeOptionalParams } from "./shared.js";
+import { coerceNumber } from "../../../../utils/query-helpers.js";
 
 // =============================================================================
 // Input Schemas
@@ -17,8 +18,7 @@ import { normalizeOptionalParams } from "./shared.js";
  */
 export const KcacheQueryStatsSchemaBase = z.object({
   limit: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Maximum number of queries to return (default: 5, min: 1, max: 10).",
     ),
@@ -28,10 +28,11 @@ export const KcacheQueryStatsSchemaBase = z.object({
     .describe(
       "Order results by metric (default: total_time). Valid: total_time, cpu_time, reads, writes",
     ),
-  minCalls: z.number().optional().describe("Minimum call count to include"),
+  minCalls: z
+    .preprocess(coerceNumber, z.number().optional())
+    .describe("Minimum call count to include"),
   queryPreviewLength: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Characters for query preview (default: 100, max: 500, 0 for full)",
     ),
@@ -53,12 +54,10 @@ export const KcacheQueryStatsSchema = z.preprocess(
  */
 export const KcacheTopCpuSchemaBase = z.object({
   limit: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe("Number of top queries to return (default: 5, min: 1, max: 10)."),
   queryPreviewLength: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Characters for query preview (default: 100, max: 500, 0 for full)",
     ),
@@ -77,12 +76,10 @@ export const KcacheTopIoSchemaBase = z.object({
   type: z.string().optional().describe("I/O type to rank by (default: both)"),
   ioType: z.string().optional().describe("Alias for type"),
   limit: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe("Number of top queries to return (default: 5, min: 1, max: 10)."),
   queryPreviewLength: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Characters for query preview (default: 100, max: 500, 0 for full)",
     ),
@@ -122,19 +119,18 @@ export const KcacheResourceAnalysisSchemaBase = z.object({
     .optional()
     .describe("Specific query ID to analyze (all if omitted)"),
   threshold: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe("CPU/IO ratio threshold for classification (default: 0.5)"),
   limit: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Maximum number of queries to return (default: 5, min: 1, max: 10).",
     ),
-  minCalls: z.number().optional().describe("Minimum call count to include"),
+  minCalls: z
+    .preprocess(coerceNumber, z.number().optional())
+    .describe("Minimum call count to include"),
   queryPreviewLength: z
-    .number()
-    .optional()
+    .preprocess(coerceNumber, z.number().optional())
     .describe(
       "Characters for query preview (default: 100, max: 500, 0 for full)",
     ),

--- a/src/adapters/postgresql/schemas/extensions/kcache.ts
+++ b/src/adapters/postgresql/schemas/extensions/kcache.ts
@@ -20,7 +20,7 @@ export const KcacheQueryStatsSchemaBase = z.object({
   limit: z
     .preprocess(coerceNumber, z.number().optional())
     .describe(
-      "Maximum number of queries to return (default: 5, min: 1, max: 10).",
+      "Maximum number of queries to return (default: 5, min: 1, max: 100).",
     ),
   orderBy: z
     .string()
@@ -55,7 +55,7 @@ export const KcacheQueryStatsSchema = z.preprocess(
 export const KcacheTopCpuSchemaBase = z.object({
   limit: z
     .preprocess(coerceNumber, z.number().optional())
-    .describe("Number of top queries to return (default: 5, min: 1, max: 10)."),
+    .describe("Number of top queries to return (default: 5, min: 1, max: 100)."),
   queryPreviewLength: z
     .preprocess(coerceNumber, z.number().optional())
     .describe(
@@ -77,7 +77,7 @@ export const KcacheTopIoSchemaBase = z.object({
   ioType: z.string().optional().describe("Alias for type"),
   limit: z
     .preprocess(coerceNumber, z.number().optional())
-    .describe("Number of top queries to return (default: 5, min: 1, max: 10)."),
+    .describe("Number of top queries to return (default: 5, min: 1, max: 100)."),
   queryPreviewLength: z
     .preprocess(coerceNumber, z.number().optional())
     .describe(
@@ -124,7 +124,7 @@ export const KcacheResourceAnalysisSchemaBase = z.object({
   limit: z
     .preprocess(coerceNumber, z.number().optional())
     .describe(
-      "Maximum number of queries to return (default: 5, min: 1, max: 10).",
+      "Maximum number of queries to return (default: 5, min: 1, max: 100).",
     ),
   minCalls: z
     .preprocess(coerceNumber, z.number().optional())

--- a/src/adapters/postgresql/schemas/partitioning/preprocess.ts
+++ b/src/adapters/postgresql/schemas/partitioning/preprocess.ts
@@ -53,6 +53,15 @@ interface RawPartitionInput {
 }
 
 /**
+ * Escape embedded single quotes in SQL string literals.
+ * Doubles `'` → `''` per SQL standard to prevent broken DDL or injection
+ * when interpolating user-provided values into partition bound clauses.
+ */
+function escapeSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
  * Preprocess partition parameters to normalize common input patterns:
  * - parentTable → parent (common alias)
  * - table → parent (common alias)
@@ -174,7 +183,7 @@ export function preprocessPartitionParams(input: unknown): unknown {
     result.to !== undefined &&
     result.forValues === undefined
   ) {
-    result.forValues = `FROM ('${result.from}') TO ('${result.to}')`;
+    result.forValues = `FROM ('${escapeSqlLiteral(result.from)}') TO ('${escapeSqlLiteral(result.to)}')`;
   }
 
   // Alias: listValues → values
@@ -188,7 +197,9 @@ export function preprocessPartitionParams(input: unknown): unknown {
     Array.isArray(result.values) &&
     result.forValues === undefined
   ) {
-    const quotedValues = result.values.map((v: string) => `'${v}'`).join(", ");
+    const quotedValues = result.values
+      .map((v: string) => `'${escapeSqlLiteral(v)}'`)
+      .join(", ");
     result.forValues = `IN (${quotedValues})`;
   }
 

--- a/src/adapters/postgresql/tools/kcache/admin.ts
+++ b/src/adapters/postgresql/tools/kcache/admin.ts
@@ -250,9 +250,8 @@ Helps identify the root cause of performance issues - is the query computation-h
         const totalCount = Number(totalRaw) || 0;
 
         const isCompact = parsed.compact ?? true;
-        const previewCol = isCompact
-          ? ""
-          : `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
+        // Always include query_preview for context, even in compact mode
+        const previewCol = `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
 
         const sql = `
                 WITH query_metrics AS (
@@ -275,7 +274,7 @@ Helps identify the root cause of performance issues - is the query computation-h
                 )
                 SELECT
                     queryid,
-                    ${isCompact ? "" : "query_preview,"}
+                    query_preview,
                     calls,
                     total_time_ms,
                     cpu_time,

--- a/src/adapters/postgresql/tools/kcache/admin.ts
+++ b/src/adapters/postgresql/tools/kcache/admin.ts
@@ -199,8 +199,8 @@ Helps identify the root cause of performance issues - is the query computation-h
         const threshold = parsed.threshold;
         const limit = parsed.limit;
 
-        if (limit !== undefined && (limit < 1 || limit > 10)) {
-          throw new ValidationError("limit must be between 1 and 10");
+        if (limit !== undefined && (limit < 1 || limit > 100)) {
+          throw new ValidationError("limit must be between 1 and 100");
         }
         const minCalls = parsed.minCalls;
         const queryPreviewLength = parsed.queryPreviewLength;

--- a/src/adapters/postgresql/tools/kcache/query.ts
+++ b/src/adapters/postgresql/tools/kcache/query.ts
@@ -125,9 +125,8 @@ orderBy options: 'total_time' (default), 'cpu_time', 'reads', 'writes'. Use minC
         const totalCount = Number(totalRaw) || 0;
 
         const isCompact = parsed.compact ?? true;
-        const previewCol = isCompact
-          ? ""
-          : `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
+        // Always include query_preview for context, even in compact mode
+        const previewCol = `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
 
         const sql = `
                 SELECT
@@ -244,9 +243,8 @@ in user CPU (application code) vs system CPU (kernel operations).`,
         const totalCount = Number(totalRaw) || 0;
 
         const isCompact = parsed.compact ?? true;
-        const previewCol = isCompact
-          ? ""
-          : `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
+        // Always include query_preview for context, even in compact mode
+        const previewCol = `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
 
         const sql = `
                 SELECT
@@ -401,9 +399,8 @@ which represent actual disk access (not just shared buffer hits).`,
         const totalCount = Number(totalRaw) || 0;
 
         const isCompact = parsed.compact ?? true;
-        const previewCol = isCompact
-          ? ""
-          : `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
+        // Always include query_preview for context, even in compact mode
+        const previewCol = `LEFT(s.query, ${String(previewLen)}) as query_preview,`;
 
         const sql = `
                 SELECT

--- a/src/adapters/postgresql/tools/kcache/query.ts
+++ b/src/adapters/postgresql/tools/kcache/query.ts
@@ -55,8 +55,8 @@ orderBy options: 'total_time' (default), 'cpu_time', 'reads', 'writes'. Use minC
 
         const limit = parsed.limit;
 
-        if (limit !== undefined && (limit < 1 || limit > 10)) {
-          throw new ValidationError("limit must be between 1 and 10");
+        if (limit !== undefined && (limit < 1 || limit > 100)) {
+          throw new ValidationError("limit must be between 1 and 100");
         }
 
         const orderBy = parsed.orderBy;
@@ -215,9 +215,9 @@ in user CPU (application code) vs system CPU (kernel operations).`,
           .parse(params ?? {});
         if (
           parsed.limit !== undefined &&
-          (parsed.limit < 1 || parsed.limit > 10)
+          (parsed.limit < 1 || parsed.limit > 100)
         ) {
-          throw new ValidationError("limit must be between 1 and 10");
+          throw new ValidationError("limit must be between 1 and 100");
         }
 
         const DEFAULT_LIMIT = 5;
@@ -343,8 +343,12 @@ which represent actual disk access (not just shared buffer hits).`,
           .parse(preprocessed);
 
         // Validate ioType inside handler for structured error response
-        const VALID_IO_TYPES = ["reads", "writes", "both"] as const;
-        const rawIoType = parsed.type ?? "both";
+        const VALID_IO_TYPES = ["read", "write", "reads", "writes", "both"] as const;
+        let rawIoType = parsed.type ?? "both";
+        // Normalize singular aliases strictly to their plural counterparts for DB column resolution
+        if (rawIoType === "read") rawIoType = "reads";
+        if (rawIoType === "write") rawIoType = "writes";
+        
         if (
           !VALID_IO_TYPES.includes(rawIoType as (typeof VALID_IO_TYPES)[number])
         ) {
@@ -356,9 +360,9 @@ which represent actual disk access (not just shared buffer hits).`,
         const ioType = rawIoType as (typeof VALID_IO_TYPES)[number];
         if (
           parsed.limit !== undefined &&
-          (parsed.limit < 1 || parsed.limit > 10)
+          (parsed.limit < 1 || parsed.limit > 100)
         ) {
-          throw new ValidationError("limit must be between 1 and 10");
+          throw new ValidationError("limit must be between 1 and 100");
         }
 
         const DEFAULT_LIMIT = 5;

--- a/src/adapters/postgresql/tools/performance/__tests__/anomaly-detection.test.ts
+++ b/src/adapters/postgresql/tools/performance/__tests__/anomaly-detection.test.ts
@@ -356,15 +356,13 @@ describe("pg_detect_bloat_risk", () => {
   });
 
   it("should filter by schema when specified", async () => {
-    // 1. Schema validation check
-    mockAdapter.executeQuery.mockResolvedValueOnce({ rows: [{ 1: 1 }] });
-    // 2. Main query
+    // Main query
     mockAdapter.executeQuery.mockResolvedValueOnce({ rows: [] });
 
     const tool = findTool(tools, "pg_detect_bloat_risk");
     await tool.handler({ schema: "sales" }, mockContext);
 
-    const sql = mockAdapter.executeQuery.mock.calls[1]?.[0] as string;
+    const sql = mockAdapter.executeQuery.mock.calls[0]?.[0] as string;
     expect(sql).toContain("schemaname = 'sales'");
   });
 

--- a/src/adapters/postgresql/tools/performance/anomaly-detection.ts
+++ b/src/adapters/postgresql/tools/performance/anomaly-detection.ts
@@ -27,8 +27,6 @@ import {
   DetectQueryAnomaliesOutputSchema,
   DetectBloatRiskOutputSchema,
 } from "../../schemas/performance.js";
-import { validatePerformanceTableExists } from "./helpers.js";
-
 // =============================================================================
 // Shared Helpers (exported for connection-analysis.ts)
 // =============================================================================
@@ -269,9 +267,7 @@ export function createDetectBloatRiskTool(
         const minRows = parsed.data.minRows ?? 1000;
         const schema = parsed.data.schema;
 
-        if (schema !== undefined) {
-          await validatePerformanceTableExists(adapter, undefined, schema);
-        }
+
 
         if (minRows < 0 || minRows > 1000000) {
           return {

--- a/src/constants/server-instructions.ts
+++ b/src/constants/server-instructions.ts
@@ -11,7 +11,7 @@
  * and instruction level for token efficiency.
  */
 
-import type { ToolGroup } from "../types/index.js";
+import type { ToolGroup } from '../types/index.js'
 
 /**
  * Instruction detail level for token efficiency
@@ -19,7 +19,7 @@ import type { ToolGroup } from "../types/index.js";
  * - standard: ~200-300 tokens - + dynamic help pointers for enabled groups
  * - full: ~350-400 tokens - + active groups summary
  */
-export type InstructionLevel = "essential" | "standard" | "full";
+export type InstructionLevel = 'essential' | 'standard' | 'full'
 
 // =============================================================================
 // Composable Instruction Segments
@@ -33,10 +33,10 @@ const CORE_INSTRUCTIONS = `# postgres-mcp (PostgreSQL MCP Server)
 
 ## Quick Access
 
-| Purpose         | Action                     |
-| --------------- | -------------------------- |
-| Health check    | \`pg_analyze_db_health\` tool |
-| Server info     | \`pg_server_version\` tool   |
+| Purpose         | Action                       |
+| --------------- | ---------------------------- |
+| Health check    | \`pg_analyze_db_health\` tool  |
+| Server info     | \`pg_server_version\` tool     |
 | Database schema | \`postgres://schema\` resource |
 | Audit & Tokens  | \`postgres://audit\` resource  |
 | Tool help       | \`postgres://help\` resource   |
@@ -51,15 +51,16 @@ For multi-step data pipelines, complex validations, or token-heavy reads (like v
 
 ## Tool Groups Showcase (200+ Tools)
 
-All tools are grouped by namespace in Code Mode (e.g. \`pg.stats.*\`, \`pg.vector.*\`). 
+All tools are grouped by namespace in Code Mode (e.g. \`pg.stats.*\`, \`pg.vector.*\`).
 Some highlights include:
+
 - **Core Operations**: \`core\`, \`transactions\`, \`migration\`, \`schema\`
 - **Data Types**: \`jsonb\`, \`text\`, \`vector\`, \`postgis\`, \`citext\`, \`ltree\`
 - **Introspection/Health**: \`introspection\`, \`monitoring\`, \`performance\`, \`kcache\`
 - **Scale/Maintenance**: \`partitioning\`, \`partman\`, \`cron\`, \`backup\`, \`admin\`
 - **Analytics**: \`stats\`, \`pgcrypto\`
 
-Review individual \`server-instructions/{group}.md\` for deep-dive examples and parameter aliases, or use \`postgres://help\` directly from the MCP.`;
+Review individual \`server-instructions/{group}.md\` for deep-dive examples and parameter aliases, or use \`postgres://help\` directly from the MCP.`
 
 /**
  * Code Mode summary — only included when codemode group is enabled.
@@ -72,62 +73,32 @@ API: \`pg_group_action\` → \`pg.group.action()\` (e.g., \`pg_jsonb_extract\` �
 Top-level: \`pg.readQuery()\`, \`pg.writeQuery()\`, \`pg.listTables()\`, \`pg.describeTable()\`, \`pg.upsert()\`, etc.
 Positional: \`readQuery("SELECT...")\`, \`exists("users", "id=1")\`, \`createIndex("users", ["email"])\`
 Discovery: \`pg.help()\` → \`{group: methods[]}\`. \`pg.core.help()\`, \`pg.jsonb.help()\` for group-specific.
-Sandbox: No \`setTimeout\`, \`setInterval\`, \`fetch\`, or network access. Use \`pg.core.readQuery()\` for data.`;
+Sandbox: No \`setTimeout\`, \`setInterval\`, \`fetch\`, or network access. Use \`pg.core.readQuery()\` for data.`
 
 /**
  * All group keys that have help content (for dynamic help pointer generation).
  */
-const HELP_GROUP_KEYS: readonly string[] = [
-  "admin",
-  "backup",
-  "citext",
-  "cron",
-  "introspection",
-  "jsonb",
-  "kcache",
-  "ltree",
-  "migration",
-  "monitoring",
-  "partitioning",
-  "partman",
-  "performance",
-  "pgcrypto",
-  "postgis",
-  "schema",
-  "stats",
-  "text",
-  "transactions",
-  "vector",
-];
+const HELP_GROUP_KEYS: readonly string[] = ["admin","backup","citext","cron","introspection","jsonb","kcache","ltree","migration","monitoring","partitioning","partman","performance","pgcrypto","postgis","schema","stats","text","transactions","vector"]
 
 /**
  * Build dynamic help pointers listing only the enabled groups.
  */
 function buildHelpPointers(groups: Set<ToolGroup>): string {
-  const enabledHelpGroups = HELP_GROUP_KEYS.filter((k) =>
-    groups.has(k as ToolGroup),
-  );
-  if (enabledHelpGroups.length === 0) {
-    return "\n\nRead `postgres://help` for gotchas and critical usage patterns.";
-  }
-  return (
-    "\n\n## Help Resources\n\n" +
-    "Read `postgres://help` for gotchas and critical usage patterns.\n" +
-    "Read `postgres://help/{group}` for: " +
-    enabledHelpGroups.join(", ") +
-    "."
-  );
+    const enabledHelpGroups = HELP_GROUP_KEYS.filter((k) => groups.has(k as ToolGroup))
+    if (enabledHelpGroups.length === 0) {
+        return '\n\nRead `postgres://help` for gotchas and critical usage patterns.'
+    }
+    return '\n\n## Help Resources\n\n' +
+        'Read `postgres://help` for gotchas and critical usage patterns.\n' +
+        'Read `postgres://help/{group}` for: ' + enabledHelpGroups.join(', ') + '.'
 }
 
 /**
  * Build active groups summary listing enabled group names with tool counts.
  */
-function buildActiveGroupsSummary(
-  groups: Set<ToolGroup>,
-  enabledToolCount: number,
-): string {
-  const groupList = [...groups].sort().join(", ");
-  return `\n\n## Active Tools (${String(enabledToolCount)})\n\nGroups: ${groupList}`;
+function buildActiveGroupsSummary(groups: Set<ToolGroup>, enabledToolCount: number): string {
+    const groupList = [...groups].sort().join(', ')
+    return `\n\n## Active Tools (${String(enabledToolCount)})\n\nGroups: ${groupList}`
 }
 
 // =============================================================================
@@ -147,40 +118,39 @@ function buildActiveGroupsSummary(
  * @param enabledToolCount - Number of enabled tools (for full level summary)
  */
 export function generateInstructions(
-  enabledGroups: Set<ToolGroup>,
-  level: InstructionLevel = "standard",
-  enabledToolCount?: number,
+    enabledGroups: Set<ToolGroup>,
+    level: InstructionLevel = 'standard',
+    enabledToolCount?: number,
 ): string {
-  // Always start with core instructions
-  let instructions = CORE_INSTRUCTIONS;
+    // Always start with core instructions
+    let instructions = CORE_INSTRUCTIONS
 
-  // Code Mode — only when codemode group is enabled
-  if (enabledGroups.has("codemode")) {
-    instructions += CODE_MODE_INSTRUCTIONS;
-  }
+    // Code Mode — only when codemode group is enabled
+    if (enabledGroups.has('codemode')) {
+        instructions += CODE_MODE_INSTRUCTIONS
+    }
 
-  // Essential: minimal help pointer (no group listing)
-  // Standard+: dynamic help pointers listing enabled groups
-  if (level === "essential") {
-    instructions +=
-      "\n\nRead `postgres://help` for gotchas and critical usage patterns.";
-  } else {
-    instructions += buildHelpPointers(enabledGroups);
-  }
+    // Essential: minimal help pointer (no group listing)
+    // Standard+: dynamic help pointers listing enabled groups
+    if (level === 'essential') {
+        instructions += '\n\nRead `postgres://help` for gotchas and critical usage patterns.'
+    } else {
+        instructions += buildHelpPointers(enabledGroups)
+    }
 
-  // Full level includes active groups summary
-  if (level === "full" && enabledToolCount !== undefined) {
-    instructions += buildActiveGroupsSummary(enabledGroups, enabledToolCount);
-  }
+    // Full level includes active groups summary
+    if (level === 'full' && enabledToolCount !== undefined) {
+        instructions += buildActiveGroupsSummary(enabledGroups, enabledToolCount)
+    }
 
-  return instructions;
+    return instructions
 }
 
 /**
  * Static instructions for backward compatibility.
  * @deprecated Use generateInstructions() instead for dynamic content
  */
-export const INSTRUCTIONS = CORE_INSTRUCTIONS;
+export const INSTRUCTIONS = CORE_INSTRUCTIONS
 
 /**
  * Help content keyed by group name.
@@ -188,14 +158,12 @@ export const INSTRUCTIONS = CORE_INSTRUCTIONS;
  * Other keys are tool groups (postgres://help/{group}).
  */
 export const HELP_CONTENT: ReadonlyMap<string, string> = new Map([
-  [
-    "admin",
-    `# Admin Tools
+  ["admin", `# Admin Tools
 
 Core: \`vacuum()\`, \`vacuumAnalyze()\`, \`analyze()\`, \`reindex()\`, \`cluster()\`, \`setConfig()\`, \`reloadConf()\`, \`resetStats()\`, \`cancelBackend()\`, \`terminateBackend()\`, \`appendInsight()\`
 
 - All admin tools support \`schema.table\` format (auto-parsed, embedded schema takes priority over explicit \`schema\` param)
-- \`vacuum({ table?, full?, analyze?, verbose? })\`: Without \`table\`, vacuums ALL tables. \`verbose\` output goes to logs. Note: Vacuum timing logic triggers log progress feedback *after* validation execution correctly.
+- \`vacuum({ table?, full?, analyze?, verbose? })\`: Without \`table\`, vacuums ALL tables. \`verbose\` output goes to logs. Note: Vacuum timing logic triggers log progress feedback _after_ validation execution correctly.
 - \`reindex({ target, name?, concurrently? })\`: Targets: 'table', 'index', 'schema', 'database'. \`database\` target defaults to current db when \`name\` omitted
 - \`cluster()\`: Without args, re-clusters all previously-clustered tables. If \`index\` is specified, \`table\` is also required.
 - \`setConfig({ name, value, isLocal? })\`: \`isLocal: true\` applies only to current transaction
@@ -210,7 +178,7 @@ Aliases: \`tableName\`→\`table\`, \`indexName\`→\`index\`, \`param\`/\`setti
 **Discovery**: \`pg.admin.help()\` returns \`{methods, methodAliases, examples}\` object
 
 **Response structures**:
-*(Note: All operations strictly adhere to P154 error handling, returning \`{success: false, error: "...", code: "..."}\` natively for domain errors and Zod validation failures).*
+_(Note: All operations strictly adhere to P154 error handling, returning \`{success: false, error: "...", code: "..."}\` natively for domain errors and Zod validation failures)._
 
 - \`vacuum()\` / \`vacuumAnalyze()\`: \`{success, message, table?, schema?, hint?}\`
 - \`analyze()\`: \`{success, message, table?, schema?, hint?}\`
@@ -219,11 +187,8 @@ Aliases: \`tableName\`→\`table\`, \`indexName\`→\`index\`, \`param\`/\`setti
 - \`setConfig()\`: \`{success, message, parameter?, value?, hint?}\`
 - \`reloadConf()\` / \`resetStats()\`: \`{success, message, hint?}\`
 - \`cancelBackend()\` / \`terminateBackend()\`: \`{success, message, pid?, hint?}\`
-- \`appendInsight()\`: \`{success, insightCount, message}\``,
-  ],
-  [
-    "backup",
-    `# Backup Tools
+- \`appendInsight()\`: \`{success, insightCount, message}\``],
+  ["backup", `# Backup Tools
 
 Core: \`dumpTable()\`, \`dumpSchema()\`, \`copyExport()\`, \`copyImport()\`, \`createBackupPlan()\`, \`restoreCommand()\`, \`physical()\`, \`restoreValidate()\`, \`scheduleOptimize()\`, \`auditListBackups()\`, \`auditDiffBackup()\`, \`auditRestoreBackup()\`
 
@@ -253,11 +218,8 @@ Response Structures:
 - \`pg_audit_diff_backup({filename})\`: Shows DDL + \`volumeDrift\` (row/size delta vs. live table). \`volumeDrift\` fields are conditional — only present when data exists. Note: Unanalyzed tables (\`reltuples = -1\`) automatically execute a fallback \`SELECT COUNT(*)\` for accurate data volume tracking. Defaults to \`compact: true\` to bypass redundant full DDL blocks and conserve tokens. Returns \`{ddl, volumeDrift?: {rowCountSnapshot?, rowCountCurrent?, sizeBytesSnapshot?, sizeBytesCurrent?, summary}}\`
 - \`pg_audit_restore_backup({filename, dryRun?, restoreAs?, confirm})\`: Transaction-wrapped restore. Use \`dryRun: true\` to preview. \`restoreAs\` creates a side-by-side copy instead of overwriting. ⚠️ \`confirm: true\` is strictly REQUIRED for destructive in-place restores. SERIAL sequences dropped with table — DDL with \`nextval()\` fails on restore; use simple types or recreate sequences first. Returns \`{success, restored, restoreAs?}\`
 
-**Top-Level Aliases**: \`pg.dumpTable()\`, \`pg.dumpSchema()\`, \`pg.copyExport()\`, \`pg.copyImport()\`, \`pg.createBackupPlan()\`, \`pg.restoreCommand()\`, \`pg.restoreValidate()\`, \`pg.physical()\`, \`pg.backupPhysical()\`, \`pg.scheduleOptimize()\`, \`pg.backupScheduleOptimize()\`, \`pg.auditListBackups()\`, \`pg.auditDiffBackup()\`, \`pg.auditRestoreBackup()\``,
-  ],
-  [
-    "citext",
-    `# citext Tools
+**Top-Level Aliases**: \`pg.dumpTable()\`, \`pg.dumpSchema()\`, \`pg.copyExport()\`, \`pg.copyImport()\`, \`pg.createBackupPlan()\`, \`pg.restoreCommand()\`, \`pg.restoreValidate()\`, \`pg.physical()\`, \`pg.backupPhysical()\`, \`pg.scheduleOptimize()\`, \`pg.backupScheduleOptimize()\`, \`pg.auditListBackups()\`, \`pg.auditDiffBackup()\`, \`pg.auditRestoreBackup()\``],
+  ["citext", `# citext Tools
 
 Core: \`createExtension()\`, \`convertColumn()\`, \`listColumns()\`, \`analyzeCandidates()\`, \`compare()\`, \`schemaAdvisor()\`
 
@@ -268,11 +230,8 @@ Core: \`createExtension()\`, \`convertColumn()\`, \`listColumns()\`, \`analyzeCa
 - \`pg_citext_compare\`: Test case-insensitive comparison. Returns \`{value1, value2, citextEqual, textEqual, lowerEqual, extensionInstalled}\`. Empty strings are handled gracefully natively without throwing validation errors.
 - \`pg_citext_schema_advisor\`: Supports \`schema.table\` format (auto-parsed). Analyzes specific table. Optional \`compact\` flag (default: \`true\`) to omit recommendations to 'keep' current types. Returns \`{table, recommendations: [{column, currentType, previousType?, recommendation, confidence, reason}], summary, nextSteps}\`. \`tableName\` alias for \`table\`. Already-citext columns include \`previousType: "text or varchar (converted)"\`
 
-**Discovery**: \`pg.citext.help()\` returns \`{methods, methodAliases, examples}\` object`,
-  ],
-  [
-    "cron",
-    `# Cron Tools (pg_cron)
+**Discovery**: \`pg.citext.help()\` returns \`{methods, methodAliases, examples}\` object`],
+  ["cron", `# Cron Tools (pg_cron)
 
 Core: \`createExtension()\`, \`schedule()\`, \`scheduleInDatabase()\`, \`unschedule()\`, \`alterJob()\`, \`listJobs()\`, \`jobRunDetails()\`, \`cleanupHistory()\`
 
@@ -285,11 +244,8 @@ Core: \`createExtension()\`, \`schedule()\`, \`scheduleInDatabase()\`, \`unsched
 - \`pg_cron_cleanup_history\`: Delete old run records. \`olderThanDays\`/\`days\` param (default: 7). Optional \`jobId\` to target specific job
 - \`pg_cron_create_extension\`: Enable pg_cron extension (idempotent). Requires superuser
 
-**Discovery**: \`pg.cron.help()\` returns \`{methods, methodAliases, examples}\` object`,
-  ],
-  [
-    "gotchas",
-    `# postgres-mcp Code Mode
+**Discovery**: \`pg.cron.help()\` returns \`{methods, methodAliases, examples}\` object`],
+  ["gotchas", `# postgres-mcp Code Mode
 
 ## ⚠️ Critical Gotchas
 
@@ -321,45 +277,45 @@ Core: \`createExtension()\`, \`schedule()\`, \`scheduleInDatabase()\`, \`unsched
 
 ## 🔄 Response Structures
 
-| Tool                          | Returns                                                                                                                                     | Notes                                                                                                                                                                                                                                                  |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| \`pg_read_query\`               | \`{rows, rowCount, fields?}\`                                                                                                                 | \`fields\` contains column metadata (name, dataTypeID)                                                                                                                                                                                                   |
-| \`pg_write_query\`              | \`{rowsAffected, rows?}\`                                                                                                                     | \`rows\` only with RETURNING clause. DDL statements return \`rowsAffected: 0\`. ⛔ Throws for SELECT                                                                                                                                                       |
-| \`pg_upsert\`                   | \`{success, operation, rowsAffected, rows?}\`                                                                                                 | \`operation: 'insert' | 'update'\`. \`rows\` only with RETURNING clause |
-| \`pg_batch_insert\`             | \`{success, rowsAffected, rows?}\`                                                                                                            | Empty objects use DEFAULT VALUES. ⚠️ BIGINT > 2^53 loses precision                                                                                                                                                                                     |
-| \`pg_create_table\`             | \`{success, table, sql, compositePrimaryKey?}\`                                                                                               | \`table\` = schema-qualified name. \`compositePrimaryKey\` only when composite PK used                                                                                                                                                                     |
-| \`pg_drop_table\`               | \`{success, dropped, existed}\`                                                                                                               | \`existed\` indicates whether table was present before drop                                                                                                                                                                                              |
-| \`pg_create_index\`             | \`{success, index, indexName, table, sql, ifNotExists?, alreadyExists?, message?}\`                                                           | \`alreadyExists\`/\`message\` only with \`ifNotExists: true\` when index pre-exists                                                                                                                                                                          |
-| \`pg_drop_index\`               | \`{success, index, existed, sql}\`                                                                                                            | \`existed\` indicates whether index was present before drop                                                                                                                                                                                              |
-| \`pg_truncate\`                 | \`{success, table, cascade, restartIdentity}\`                                                                                                | \`cascade\`/\`restartIdentity\` reflect the options used                                                                                                                                                                                                   |
-| \`pg_count\`                    | \`{count: N}\`                                                                                                                                | Use \`params\` for placeholders: \`where: 'id=$1', params: [5]\`. DISTINCT: use \`pg_read_query\`                                                                                                                                                            |
-| \`pg_exists\`                   | \`{exists: bool, mode, hint?}\`                                                                                                               | \`params\` for placeholders. \`mode: 'filtered' | 'any_rows'\`                                                                                                                                                                                           |
-| \`pg_get_indexes\`              | \`{indexes, count, totalCount?}\`                                                                                                             | Default \`limit: 100\` without \`table\`. Use \`schema\`/\`limit\` to filter. Index objects have \`name\`, \`type\`, \`columns\`                                                                                                                                     |
-| \`pg_list_objects\`             | \`{objects, count, totalCount, byType}\`                                                                                                      | Use \`limit\` to cap results, \`type\`/\`types\` to filter                                                                                                                                                                                                   |
-| \`pg_object_details\`           | \`{name, schema, type, returnType?, ...}\`                                                                                                    | Functions: \`returnType\` alias. Views/Mat. views: \`definition\`. Tables: equivalent to \`pg_describe_table\` (columns, primaryKey, indexes, constraints, foreignKeys)                                                                                      |
-| \`pg_analyze_db_health\`        | \`{cacheHitRatio, databaseSize, tableStats, unusedIndexes, tablesNeedingVacuum, connections, bloat, isReplica, overallScore, overallStatus}\` | \`cacheHitRatio\`: \`{ratio, heap, index, status}\`. \`overallStatus\`: \`healthy | needs_attention | critical\`. Optional sections via \`includeIndexes\`, \`includeVacuum\`, \`includeConnections\` |
+| Tool                          | Returns                                                                                                                                     | Notes                                                                                                                                                                                                                                                                                           |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| \`pg_read_query\`               | \`{rows, rowCount, fields?}\`                                                                                                                 | \`fields\` contains column metadata (name, dataTypeID)                                                                                                                                                                                                                                            |
+| \`pg_write_query\`              | \`{rowsAffected, rows?}\`                                                                                                                     | \`rows\` only with RETURNING clause. DDL statements return \`rowsAffected: 0\`. ⛔ Throws for SELECT                                                                                                                                                                                                |
+| \`pg_upsert\`                   | \`{success, operation, rowsAffected, rows?}\`                                                                                                 | \`operation: 'insert'                                                                                                                                                                                                                                                                            | 'update'\`. \`rows\` only with RETURNING clause |
+| \`pg_batch_insert\`             | \`{success, rowsAffected, rows?}\`                                                                                                            | Empty objects use DEFAULT VALUES. ⚠️ BIGINT > 2^53 loses precision                                                                                                                                                                                                                              |
+| \`pg_create_table\`             | \`{success, table, sql, compositePrimaryKey?}\`                                                                                               | \`table\` = schema-qualified name. \`compositePrimaryKey\` only when composite PK used                                                                                                                                                                                                              |
+| \`pg_drop_table\`               | \`{success, dropped, existed}\`                                                                                                               | \`existed\` indicates whether table was present before drop                                                                                                                                                                                                                                       |
+| \`pg_create_index\`             | \`{success, index, indexName, table, sql, ifNotExists?, alreadyExists?, message?}\`                                                           | \`alreadyExists\`/\`message\` only with \`ifNotExists: true\` when index pre-exists                                                                                                                                                                                                                   |
+| \`pg_drop_index\`               | \`{success, index, existed, sql}\`                                                                                                            | \`existed\` indicates whether index was present before drop                                                                                                                                                                                                                                       |
+| \`pg_truncate\`                 | \`{success, table, cascade, restartIdentity}\`                                                                                                | \`cascade\`/\`restartIdentity\` reflect the options used                                                                                                                                                                                                                                            |
+| \`pg_count\`                    | \`{count: N}\`                                                                                                                                | Use \`params\` for placeholders: \`where: 'id=$1', params: [5]\`. DISTINCT: use \`pg_read_query\`                                                                                                                                                                                                     |
+| \`pg_exists\`                   | \`{exists: bool, mode, hint?}\`                                                                                                               | \`params\` for placeholders. \`mode: 'filtered'                                                                                                                                                                                                                                                    | 'any_rows'\`                                  |
+| \`pg_get_indexes\`              | \`{indexes, count, totalCount?}\`                                                                                                             | Default \`limit: 100\` without \`table\`. Use \`schema\`/\`limit\` to filter. Index objects have \`name\`, \`type\`, \`columns\`                                                                                                                                                                              |
+| \`pg_list_objects\`             | \`{objects, count, totalCount, byType}\`                                                                                                      | Use \`limit\` to cap results, \`type\`/\`types\` to filter                                                                                                                                                                                                                                            |
+| \`pg_object_details\`           | \`{name, schema, type, returnType?, ...}\`                                                                                                    | Functions: \`returnType\` alias. Views/Mat. views: \`definition\`. Tables: equivalent to \`pg_describe_table\` (columns, primaryKey, indexes, constraints, foreignKeys)                                                                                                                               |
+| \`pg_analyze_db_health\`        | \`{cacheHitRatio, databaseSize, tableStats, unusedIndexes, tablesNeedingVacuum, connections, bloat, isReplica, overallScore, overallStatus}\` | \`cacheHitRatio\`: \`{ratio, heap, index, status}\`. \`overallStatus\`: \`healthy                                                                                                                                                                                                                      | needs_attention                              | critical\`. Optional sections via \`includeIndexes\`, \`includeVacuum\`, \`includeConnections\` |
 | \`pg_describe_table\`           | \`{name, schema, type, owner?, rowCount, columns, primaryKey, indexes, constraints, foreignKeys}\`                                            | Columns include \`notNull\`, optional \`primaryKey\`, \`defaultValue\`, \`foreignKey\` (omitted when false/null). \`constraints\` includes PK, UNIQUE, CHECK, NOT NULL. ⚠️ \`rowCount: -1\` = stale/missing statistics (run ANALYZE on the table). Small tables (<~50 rows) may show -1 until first ANALYZE |
-| \`pg_analyze_query_indexes\`    | \`{plan, issues, recommendations}\`                                                                                                           | \`verbosity\`: 'summary' (default) or 'full'. Summary mode returns condensed plan                                                                                                                                                                        |
-| \`pg_list_tables\`              | \`{tables, count, totalCount, truncated?, hint?}\`                                                                                            | Use \`schema\` to filter, \`limit\` to cap results, \`exclude\` to hide extension schemas (e.g., \`['cron', 'topology', 'partman']\`)                                                                                                                          |
-| List operations               | \`{items, count, truncated?, totalCount?}\`                                                                                                                            | Many list operations heavily truncate results (e.g. 50/100 limit). Access via \`result.views\`, \`result.sequences\`, \`result.results\`. Pass \`limit: 0\` for all rows.                                                                                                                                                                                                       |
-| \`pg_jsonb_agg groupBy\`        | \`{result: [{group_key, items}], count, grouped: true}\`                                                                                      | Without groupBy: \`{result: [...], count, grouped: false}\`                                                                                                                                                                                              |
-| \`pg_vector_aggregate\`         | \`{average_vector, count}\` or \`{groups: [{group_key, average_vector, count}]}\`                                                               | Without/with \`groupBy\`                                                                                                                                                                                                                                 |
-| \`pg_index_stats\`              | \`{indexes, count, truncated?, totalCount?}\`                                                                                                 | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                |
-| \`pg_table_stats\`              | \`{tables, count, truncated?, totalCount?}\`                                                                                                  | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                |
-| \`pg_vacuum_stats\`             | \`{tables, count, truncated?, totalCount?}\`                                                                                                  | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                |
-| \`pg_stat_statements\`          | \`{statements, count, truncated?, totalCount?}\`                                                                                              | Default 20 rows. \`orderBy\` supported                                                                                                                                                                                                                   |
-| \`pg_query_plan_stats\`         | \`{queryPlanStats, count, truncated?, totalCount?}\`                                                                                          | Default 20 rows. \`truncateQuery: 0\` for full text                                                                                                                                                                                                      |
-| \`pg_stat_activity\`            | \`{connections, count, backgroundWorkers}\`                                                                                                   | \`includeIdle: true\` to include idle connections. \`backgroundWorkers\` = count of background worker processes                                                                                                                                            |
-| \`pg_locks\`                    | \`{locks}\`                                                                                                                                   | \`showBlocked: true\` switches to blocked/blocking pid format                                                                                                                                                                                            |
-| \`pg_bloat_check\`              | \`{tables, count}\`                                                                                                                           | Tables with \`live_tuples\`, \`dead_tuples\`, \`dead_pct\`                                                                                                                                                                                                   |
-| \`pg_cache_hit_ratio\`          | \`{heap_read, heap_hit, cache_hit_ratio}\`                                                                                                    | All fields nullable (0 tables = null). Flat response, differs from \`pg_analyze_db_health.cacheHitRatio\`                                                                                                                                                |
-| \`pg_seq_scan_tables\`          | \`{tables, count, minScans, hint, truncated?, totalCount?}\`                                                                                  | Default 50 rows. \`minScans\` default: 10                                                                                                                                                                                                                |
-| \`pg_connection_pool_optimize\` | \`{current, config, waitEvents, recommendations}\`                                                                                            | No params needed                                                                                                                                                                                                                                       |
-| \`pg_performance_baseline\`     | \`{name, timestamp, metrics}\`                                                                                                                | \`metrics\`: \`cache\`, \`tables\`, \`indexes\`, \`connections\`, \`databaseSize\`                                                                                                                                                                                 |
-| \`pg_duplicate_indexes\`        | \`{duplicateIndexes, count, hint, truncated?, totalCount?}\`                                                                                  | Default 50 rows. \`duplicate_type\`: EXACT_DUPLICATE, OVERLAPPING, SUBSET                                                                                                                                                                                |
-| \`pg_query_plan_compare\`       | \`{query1, query2, analysis, fullPlans, compact?}\`                                                                                                     | \`analysis.costDifference\` + \`recommendation\`. Pass \`compact: true\` to suppress massive \`fullPlans\` JSON.                                                                                                                                                                                                           |
-| \`pg_unused_indexes\`           | \`{unusedIndexes, count, hint, truncated?, totalCount?}\`                                                                                     | Default 20 rows. \`summary: true\` → \`{summary, bySchema, totalCount}\`                                                                                                                                                                                   |
-| All tools                     | \`_meta.tokenEstimate\` in \`content[].text\`                                                                                                   | Every response wraps result with \`{ ...result, _meta: { tokenEstimate: N } }\`. Token cost heuristic: ~4 bytes/token (~4 chars). \`structuredContent\` stays schema-pure (no \`_meta\`). Code Mode adds \`metrics.tokenEstimate\` instead.                    |
+| \`pg_analyze_query_indexes\`    | \`{plan, issues, recommendations}\`                                                                                                           | \`verbosity\`: 'summary' (default) or 'full'. Summary mode returns condensed plan                                                                                                                                                                                                                 |
+| \`pg_list_tables\`              | \`{tables, count, totalCount, truncated?, hint?}\`                                                                                            | Use \`schema\` to filter, \`limit\` to cap results, \`exclude\` to hide extension schemas (e.g., \`['cron', 'topology', 'partman']\`)                                                                                                                                                                   |
+| List operations               | \`{items, count, truncated?, totalCount?}\`                                                                                                   | Many list operations heavily truncate results (e.g. 50/100 limit). Access via \`result.views\`, \`result.sequences\`, \`result.results\`. Pass \`limit: 0\` for all rows.                                                                                                                               |
+| \`pg_jsonb_agg groupBy\`        | \`{result: [{group_key, items}], count, grouped: true}\`                                                                                      | Without groupBy: \`{result: [...], count, grouped: false}\`                                                                                                                                                                                                                                       |
+| \`pg_vector_aggregate\`         | \`{average_vector, count}\` or \`{groups: [{group_key, average_vector, count}]}\`                                                               | Without/with \`groupBy\`                                                                                                                                                                                                                                                                          |
+| \`pg_index_stats\`              | \`{indexes, count, truncated?, totalCount?}\`                                                                                                 | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                                                         |
+| \`pg_table_stats\`              | \`{tables, count, truncated?, totalCount?}\`                                                                                                  | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                                                         |
+| \`pg_vacuum_stats\`             | \`{tables, count, truncated?, totalCount?}\`                                                                                                  | Default 50 rows. Use \`limit: 0\` for all                                                                                                                                                                                                                                                         |
+| \`pg_stat_statements\`          | \`{statements, count, truncated?, totalCount?}\`                                                                                              | Default 20 rows. \`orderBy\` supported                                                                                                                                                                                                                                                            |
+| \`pg_query_plan_stats\`         | \`{queryPlanStats, count, truncated?, totalCount?}\`                                                                                          | Default 20 rows. \`truncateQuery: 0\` for full text                                                                                                                                                                                                                                               |
+| \`pg_stat_activity\`            | \`{connections, count, backgroundWorkers}\`                                                                                                   | \`includeIdle: true\` to include idle connections. \`backgroundWorkers\` = count of background worker processes                                                                                                                                                                                     |
+| \`pg_locks\`                    | \`{locks}\`                                                                                                                                   | \`showBlocked: true\` switches to blocked/blocking pid format                                                                                                                                                                                                                                     |
+| \`pg_bloat_check\`              | \`{tables, count}\`                                                                                                                           | Tables with \`live_tuples\`, \`dead_tuples\`, \`dead_pct\`                                                                                                                                                                                                                                            |
+| \`pg_cache_hit_ratio\`          | \`{heap_read, heap_hit, cache_hit_ratio}\`                                                                                                    | All fields nullable (0 tables = null). Flat response, differs from \`pg_analyze_db_health.cacheHitRatio\`                                                                                                                                                                                         |
+| \`pg_seq_scan_tables\`          | \`{tables, count, minScans, hint, truncated?, totalCount?}\`                                                                                  | Default 50 rows. \`minScans\` default: 10                                                                                                                                                                                                                                                         |
+| \`pg_connection_pool_optimize\` | \`{current, config, waitEvents, recommendations}\`                                                                                            | No params needed                                                                                                                                                                                                                                                                                |
+| \`pg_performance_baseline\`     | \`{name, timestamp, metrics}\`                                                                                                                | \`metrics\`: \`cache\`, \`tables\`, \`indexes\`, \`connections\`, \`databaseSize\`                                                                                                                                                                                                                          |
+| \`pg_duplicate_indexes\`        | \`{duplicateIndexes, count, hint, truncated?, totalCount?}\`                                                                                  | Default 50 rows. \`duplicate_type\`: EXACT_DUPLICATE, OVERLAPPING, SUBSET                                                                                                                                                                                                                         |
+| \`pg_query_plan_compare\`       | \`{query1, query2, analysis, fullPlans, compact?}\`                                                                                           | \`analysis.costDifference\` + \`recommendation\`. Pass \`compact: true\` to suppress massive \`fullPlans\` JSON.                                                                                                                                                                                        |
+| \`pg_unused_indexes\`           | \`{unusedIndexes, count, hint, truncated?, totalCount?}\`                                                                                     | Default 20 rows. \`summary: true\` → \`{summary, bySchema, totalCount}\`                                                                                                                                                                                                                            |
+| All tools                     | \`_meta.tokenEstimate\` in \`content[].text\`                                                                                                   | Every response wraps result with \`{ ...result, _meta: { tokenEstimate: N } }\`. Token cost heuristic: ~4 bytes/token (~4 chars). \`structuredContent\` stays schema-pure (no \`_meta\`). Code Mode adds \`metrics.tokenEstimate\` instead.                                                             |
 
 💡 **Token Optimization**: Monitor \`_meta.tokenEstimate\` on responses. For multi-step tasks or large result sets, use **Code Mode** (\`pg_execute_code\`) to execute logic server-side. Check \`postgres://audit\` for a full session token summary.
 
@@ -385,11 +341,8 @@ Core: \`createExtension()\`, \`schedule()\`, \`scheduleInDatabase()\`, \`unsched
 
 No \`setTimeout\`, \`setInterval\`, \`fetch\`, or network access. Use \`pg.core.readQuery()\` for data access.
 
-📊 **Metrics Note**: \`memoryUsedMb\` measures heap delta (end - start). Negative values indicate memory freed during execution (e.g., GC ran). \`metrics.tokenEstimate\` = estimated token cost of the sandbox result (~4 bytes/token).`,
-  ],
-  [
-    "introspection",
-    `# Introspection Tools
+📊 **Metrics Note**: \`memoryUsedMb\` measures heap delta (end - start). Negative values indicate memory freed during execution (e.g., GC ran). \`metrics.tokenEstimate\` = estimated token cost of the sandbox result (~4 bytes/token).`],
+  ["introspection", `# Introspection Tools
 
 Code Mode: \`pg.introspection.*\` — 6 read-only tools for schema analysis.
 Core: \`dependencyGraph()\`, \`topologicalSort()\`, \`cascadeSimulator()\`, \`schemaSnapshot()\`, \`constraintAnalysis()\`, \`migrationRisks()\`
@@ -403,11 +356,8 @@ Core: \`dependencyGraph()\`, \`topologicalSort()\`, \`cascadeSimulator()\`, \`sc
 - \`pg_constraint_analysis\`: Identifies constraint issues. Params: \`schema?\`, \`table?\`, \`checks?\`: \`['redundant','missing_fk','missing_not_null','missing_pk','unindexed_fk']\`, \`excludeExtensionSchemas?\` (default: true). Returns \`{findings, summary}\`
 - \`pg_migration_risks\`: Static DDL risk assessment. Params: \`statements\` (aliases: \`statement\`, \`sql\`), \`schema?\` (default: public). ⚠️ Does NOT validate object existence—analyzes SQL patterns only. Returns \`{risks, summary}\`
 
-**Discovery**: \`pg.introspection.help()\` returns \`{methods, methodAliases, examples}\``,
-  ],
-  [
-    "jsonb",
-    `# JSONB Tools
+**Discovery**: \`pg.introspection.help()\` returns \`{methods, methodAliases, examples}\``],
+  ["jsonb", `# JSONB Tools
 
 - \`pg_jsonb_extract\`: Returns null if path doesn't exist
 - \`pg_jsonb_insert\`: Index -1 inserts BEFORE last element; use \`insertAfter: true\` to append. ⚠️ Use array format \`[-1]\` not string \`"[-1]"\` for negative indices
@@ -429,24 +379,18 @@ Core: \`dependencyGraph()\`, \`topologicalSort()\`, \`cascadeSimulator()\`, \`sc
 - 📦 **AI-Optimized Payloads**: \`contains\` and \`pathQuery\` default to 100 results. Returns \`truncated\` + \`totalCount\` when capped. Use \`limit: 0\` for all rows
 - 💡 **Response Shapes**: Several tools return custom keys instead of standard \`.rows\`: \`pg_jsonb_keys\` returns \`{keys: [...]}\`, \`pg_jsonb_typeof\` returns \`{types: [...]}\`, \`pg_jsonb_path_query\` returns \`{results: [...]}\`, \`pg_jsonb_array\` returns \`{array: [...]}\`, \`pg_jsonb_index_suggest\` returns \`{recommendations: [...]}\`, \`pg_jsonb_security_scan\` returns \`{riskLevel, scanResults: [...]}\`, \`pg_jsonb_diff\` returns \`{differences: [...]}\`, and \`pg_jsonb_extract\` maps extraction to \`[{value: ...}]\`.
 
-**Top-Level Aliases**: \`pg.jsonbExtract()\`, \`pg.jsonbSet()\`, \`pg.jsonbInsert()\`, \`pg.jsonbDelete()\`, \`pg.jsonbContains()\`, \`pg.jsonbPathQuery()\`, \`pg.jsonbAgg()\`, \`pg.jsonbObject()\`, \`pg.jsonbArray()\`, \`pg.jsonbKeys()\`, \`pg.jsonbStripNulls()\`, \`pg.jsonbTypeof()\`, \`pg.jsonbValidatePath()\`, \`pg.jsonbMerge()\`, \`pg.jsonbNormalize()\`, \`pg.jsonbDiff()\`, \`pg.jsonbIndexSuggest()\`, \`pg.jsonbSecurityScan()\`, \`pg.jsonbStats()\`, \`pg.jsonbPretty()\``,
-  ],
-  [
-    "kcache",
-    `# pg_stat_kcache Tools
+**Top-Level Aliases**: \`pg.jsonbExtract()\`, \`pg.jsonbSet()\`, \`pg.jsonbInsert()\`, \`pg.jsonbDelete()\`, \`pg.jsonbContains()\`, \`pg.jsonbPathQuery()\`, \`pg.jsonbAgg()\`, \`pg.jsonbObject()\`, \`pg.jsonbArray()\`, \`pg.jsonbKeys()\`, \`pg.jsonbStripNulls()\`, \`pg.jsonbTypeof()\`, \`pg.jsonbValidatePath()\`, \`pg.jsonbMerge()\`, \`pg.jsonbNormalize()\`, \`pg.jsonbDiff()\`, \`pg.jsonbIndexSuggest()\`, \`pg.jsonbSecurityScan()\`, \`pg.jsonbStats()\`, \`pg.jsonbPretty()\``],
+  ["kcache", `# pg_stat_kcache Tools
 
 Core: \`createExtension()\`, \`queryStats()\`, \`topCpu()\`, \`topIo()\`, \`databaseStats()\`, \`resourceAnalysis()\`, \`reset()\`
 
-- \`pg_kcache_query_stats\`: \`limit\` param (default: 5, max: 10). Returns \`truncated\` + \`totalCount\` when limited. \`orderBy\`: 'total_time' (default), 'cpu_time', 'reads', 'writes'. \`queryPreviewLength\`: chars for query preview (default: 100, max: 500, 0 for full). \`compact\`: boolean (default: true, omits query_preview text and 0/empty fields). ⛔ 'calls' NOT valid for orderBy—use \`minCalls\` param
-- \`pg_kcache_resource_analysis\`: \`limit\` param (default: 5, max: 10). Returns \`truncated\` + \`totalCount\` when limited. \`minCalls\`, \`queryPreviewLength\`, and \`compact\` supported. Classifies queries as 'CPU-bound', 'I/O-bound', or 'Balanced'
-- \`pg_kcache_top_cpu\`: Top CPU-consuming queries. \`limit\` param (default: 5, max: 10). \`queryPreviewLength\` and \`compact\` supported. Returns \`truncated\` + \`totalCount\` when limited
-- \`pg_kcache_top_io\`: \`type\`/\`ioType\` (alias): 'reads', 'writes', 'both' (default). \`limit\` param (default: 5, max: 10). \`queryPreviewLength\` and \`compact\` supported. Returns \`truncated\` + \`totalCount\` when limited
+- \`pg_kcache_query_stats\`: \`limit\` param (default: 5, max: 100). Returns \`truncated\` + \`totalCount\` when limited. \`orderBy\`: 'total_time' (default), 'cpu_time', 'reads', 'writes'. \`queryPreviewLength\`: chars for query preview (default: 100, max: 500, 0 for full). \`compact\`: boolean (default: true, omits 0/empty fields). ⛔ 'calls' NOT valid for orderBy—use \`minCalls\` param
+- \`pg_kcache_resource_analysis\`: \`limit\` param (default: 5, max: 100). Returns \`truncated\` + \`totalCount\` when limited. \`minCalls\`, \`queryPreviewLength\`, and \`compact\` supported. Classifies queries as 'CPU-bound', 'I/O-bound', or 'Balanced'
+- \`pg_kcache_top_cpu\`: Top CPU-consuming queries. \`limit\` param (default: 5, max: 100). \`queryPreviewLength\` and \`compact\` supported. Returns \`truncated\` + \`totalCount\` when limited
+- \`pg_kcache_top_io\`: \`type\`/\`ioType\` (alias): 'reads', 'writes', 'both' (default). \`limit\` param (default: 5, max: 100). \`queryPreviewLength\` and \`compact\` supported. Returns \`truncated\` + \`totalCount\` when limited
 - \`pg_kcache_database_stats\`: Aggregated CPU/IO stats per database. Optional \`database\` param to filter specific db. \`compact\`: boolean (default: true, omits 0/empty fields to save tokens)
-- \`pg_kcache_reset\`: Resets pg_stat_kcache AND pg_stat_statements statistics`,
-  ],
-  [
-    "ltree",
-    `# ltree Tools
+- \`pg_kcache_reset\`: Resets pg_stat_kcache AND pg_stat_statements statistics`],
+  ["ltree", `# ltree Tools
 
 Core: \`createExtension()\`, \`query()\`, \`match()\`, \`subpath()\`, \`lca()\`, \`listColumns()\`, \`convertColumn()\`, \`createIndex()\`
 
@@ -461,11 +405,8 @@ Core: \`createExtension()\`, \`query()\`, \`match()\`, \`subpath()\`, \`lca()\`,
 - \`pg_ltree_convert_column\`: Convert TEXT column to ltree. Supports \`schema.table\` format. Returns \`{previousType, wasAlreadyLtree}\`. ⚠️ When views depend on column, returns \`{success: false, dependentViews, hint}\`—drop/recreate views manually
 - \`pg_ltree_create_index\`: Create GiST index on ltree column. Supports \`schema.table\` format. Auto-generates index name if \`indexName\` omitted. Returns \`{indexName, indexType: 'gist', alreadyExists?}\`
 
-**Discovery**: \`pg.ltree.help()\` returns \`{methods, methodAliases, examples}\` object. Top-level aliases available: \`pg.ltreeQuery()\`, \`pg.ltreeMatch()\`, etc.`,
-  ],
-  [
-    "migration",
-    `# Migration Tools
+**Discovery**: \`pg.ltree.help()\` returns \`{methods, methodAliases, examples}\` object. Top-level aliases available: \`pg.ltreeQuery()\`, \`pg.ltreeMatch()\`, etc.`],
+  ["migration", `# Migration Tools
 
 Code Mode: \`pg.migration.*\` — 6 tools for schema migration tracking and management.
 Core: \`init()\`, \`record()\`, \`apply()\`, \`rollback()\`, \`history()\`, \`status()\`
@@ -479,11 +420,8 @@ Core: \`init()\`, \`record()\`, \`apply()\`, \`rollback()\`, \`history()\`, \`st
 
 > **Note**: All tools support P154 Structured Errors and will return \`{success: false, error: "...", code: "...", category: "...", recoverable: boolean}\` on failure rather than throwing raw MCP exceptions.
 
-**Discovery**: \`pg.migration.help()\` returns \`{methods, methodAliases, examples}\``,
-  ],
-  [
-    "monitoring",
-    `# Monitoring Tools
+**Discovery**: \`pg.migration.help()\` returns \`{methods, methodAliases, examples}\``],
+  ["monitoring", `# Monitoring Tools
 
 Code Mode: \`pg.monitoring.*\` — \`databaseSize()\`, \`tableSizes()\`, \`connectionStats()\`, \`showSettings()\`, \`capacityPlanning()\`, \`uptime()\`, \`serverVersion()\`, \`recoveryStatus()\`, \`replicationStatus()\`, \`resourceUsageAnalyze()\`, \`alertThresholdSet()\`
 
@@ -508,11 +446,8 @@ Code Mode: \`pg.monitoring.*\` — \`databaseSize()\`, \`tableSizes()\`, \`conne
 
 Aliases: \`connections\`/\`activeConnections\`→\`connectionStats\`, \`tables\`→\`tableSizes\`, \`settings\`/\`config\`→\`showSettings\`, \`alerts\`/\`thresholds\`→\`alertThresholdSet\`, \`systemHealth\`→\`resourceUsageAnalyze\`
 
-**Top-Level Aliases**: \`pg.databaseSize()\`, \`pg.tableSizes()\`, \`pg.connectionStats()\`, \`pg.activeConnections()\`, \`pg.serverVersion()\`, \`pg.uptime()\`, \`pg.showSettings()\`, \`pg.recoveryStatus()\`, \`pg.replicationStatus()\`, \`pg.capacityPlanning()\`, \`pg.resourceUsageAnalyze()\`, \`pg.systemHealth()\`, \`pg.alertThresholdSet()\``,
-  ],
-  [
-    "partitioning",
-    `# Partitioning Tools
+**Top-Level Aliases**: \`pg.databaseSize()\`, \`pg.tableSizes()\`, \`pg.connectionStats()\`, \`pg.activeConnections()\`, \`pg.serverVersion()\`, \`pg.uptime()\`, \`pg.showSettings()\`, \`pg.recoveryStatus()\`, \`pg.replicationStatus()\`, \`pg.capacityPlanning()\`, \`pg.resourceUsageAnalyze()\`, \`pg.systemHealth()\`, \`pg.alertThresholdSet()\``],
+  ["partitioning", `# Partitioning Tools
 
 - \`pg_create_partitioned_table\`: \`partitionBy\` case-insensitive. Accepts \`name\` or \`table\` alias for target. \`partitionKey\` (alias \`key\`) is a string (e.g., \`"created_at"\` or \`"id, created_at"\`). \`primaryKey\` accepts array (e.g., \`['id', 'event_date']\`). Supports \`ifNotExists: true\`. ⛔ \`primaryKey\`/\`unique\` must include partition key—throws validation error otherwise
 - \`pg_create_partition\`: Use \`parent\`/\`table\`/\`parentTable\` for parent. Use \`name\` or \`partitionName\` for partition. Use bounds aliases \`from\`/\`to\` (RANGE), \`values\` array (LIST), or \`modulus\`/\`remainder\` (HASH). Alternatively, \`forValues\` takes a raw SQL string. For DEFAULT partition, use \`isDefault: true\`. Supports \`ifNotExists: true\`. Supports \`schema.table\` format for \`parent\` (auto-parsed)
@@ -523,11 +458,8 @@ Aliases: \`connections\`/\`activeConnections\`→\`connectionStats\`, \`tables\`
 - Response structures: \`pg_create_partitioned_table\` → \`{success, table, partitionBy, partitionKey, primaryKey?, alreadyExists?}\`. \`pg_create_partition\` → \`{success, partition, parent, bounds, subpartitionBy?, subpartitionKey?, alreadyExists?}\`. \`pg_attach_partition\` → \`{success, parent, partition, bounds}\`. \`pg_detach_partition\` → \`{success, parent, partition}\`
 - \`alreadyExists\` is only present when \`ifNotExists: true\` is passed; \`true\` = table/partition pre-existed, \`false\` = newly created
 - ⚠️ Sub-partitioning: \`subpartitionBy\`/\`subpartitionKey\` on \`pg_create_partition\` makes a partition itself partitionable. The parent's \`primaryKey\` must include the sub-partition key column (PostgreSQL constraint)
-- 📍 Code Mode: \`pg.partitioning.create()\` = \`createPartition\`, NOT \`createPartitionedTable\``,
-  ],
-  [
-    "partman",
-    `# pg_partman Tools
+- 📍 Code Mode: \`pg.partitioning.create()\` = \`createPartition\`, NOT \`createPartitionedTable\``],
+  ["partman", `# pg_partman Tools
 
 - \`pg_partman_create_parent\`: Interval uses PostgreSQL syntax ('1 day', '1 month') NOT keywords ('daily'). \`startPartition\` accepts 'now' shorthand for current date. Required params: \`parentTable\`/\`table\`, \`controlColumn\`/\`control\`/\`column\`, \`interval\`
 - \`pg_partman_run_maintenance\`: Without \`parentTable\`, maintains ALL partition sets. Returns \`partial: true\` when some tables are skipped. \`orphaned\` object groups orphaned configs with \`count\`, \`tables\`, and cleanup \`hint\`. \`errors\` array for other failures
@@ -539,11 +471,8 @@ Aliases: \`connections\`/\`activeConnections\`→\`connectionStats\`, \`tables\`
 - \`pg_partman_analyze_partition_health\`: Default \`limit: 50\` (use \`0\` for all). Returns \`truncated\` + \`totalCount\` when limited. \`summary.overallHealth\`: 'healthy'|'warnings'|'issues_found'
 - 📝 **Schema Resolution**: All partman tools auto-prefix \`public.\` when no schema specified in \`parentTable\`
 - 📝 **Aliases**: \`parentTable\` accepts \`table\`, \`parent\`, \`name\`. \`controlColumn\` accepts \`control\`, \`column\`, \`partitionColumn\`. \`targetTable\` accepts \`target\`. \`retentionKeepTable\` accepts \`keepTable\`.
-- 📝 **Strict Error Handling**: Attempting to query unmanaged tables (e.g. via \`pg_partman_show_config\`) throws \`TABLE_NOT_FOUND\`. Missing the extension completely throws \`EXTENSION_MISSING\` — remediate via \`pg_partman_create_extension\` before using partman tools.`,
-  ],
-  [
-    "performance",
-    `# Performance Tools
+- 📝 **Strict Error Handling**: Attempting to query unmanaged tables (e.g. via \`pg_partman_show_config\`) throws \`TABLE_NOT_FOUND\`. Missing the extension completely throws \`EXTENSION_MISSING\` — remediate via \`pg_partman_create_extension\` before using partman tools.`],
+  ["performance", `# Performance Tools
 
 Core (24 methods): \`explain()\`, \`explainAnalyze()\`, \`explainBuffers()\`, \`indexStats()\`, \`tableStats()\`, \`statStatements()\`, \`statActivity()\`, \`locks()\`, \`bloatCheck()\`, \`cacheHitRatio()\`, \`seqScanTables()\`, \`indexRecommendations()\`, \`queryPlanCompare()\`, \`baseline()\`, \`connectionPoolOptimize()\`, \`partitionStrategySuggest()\`, \`unusedIndexes()\`, \`duplicateIndexes()\`, \`vacuumStats()\`, \`queryPlanStats()\`, \`diagnoseDatabasePerformance()\`, \`detectQueryAnomalies()\`, \`detectBloatRisk()\`, \`detectConnectionSpike()\`
 
@@ -571,18 +500,15 @@ Aliases: \`cacheStats\`→\`cacheHitRatio\`, \`queryStats\`→\`statStatements\`
 - \`locks({ showBlocked?, limit? })\`: Default 100 rows, **max 100**. Returns \`count\` + \`truncated\`. \`limit: 0\` returns up to the 100-row cap. \`showBlocked: true\` returns blocking/blocked query pairs instead of the full lock list
 - \`statActivity({ includeIdle?, limit?, truncateQuery? })\`: Default 100 connections (excludes idle), **max 100**, queries truncated to 100 chars. Returns \`count\`, \`truncated\`, and \`backgroundWorkers\`. \`limit: 0\` returns up to the 100-row cap; \`includeIdle: true\` to include idle connections
 - \`detectQueryAnomalies({ threshold?, minCalls? })\`: \`threshold\` must be 0.5–10 (default 2.0); \`minCalls\` must be 1–10000 (default 10). Out-of-range values return a structured validation error
-- \`detectBloatRisk({ minRows?, schema? })\`: \`minRows\` must be 0–1,000,000 (default 1000). Nonexistent \`schema\` returns a structured \`NOT_FOUND\` error.
+- \`detectBloatRisk({ minRows?, schema? })\`: \`minRows\` must be 0–1,000,000 (default 1000). Nonexistent \`schema\` returns an empty array instead of a structured error.
 - \`detectConnectionSpike({ warningPercent? })\`: Default 70. Flags users/apps holding ≥ \`warningPercent\`% of connections. Value is clamped to 10–100 (not \`threshold\` — that key is ignored)
 
 📍 **Code Mode Note**: \`pg_performance_baseline\` → \`pg.performance.baseline({ name? })\` (not \`performanceBaseline\`). Optional \`name\` param labels the snapshot; defaults to an ISO timestamp. \`indexRecommendations\` accepts \`query\` alias for \`sql\`
 
 ⚠️ **Extension Dependency**: \`diagnoseDatabasePerformance\` uses \`pg_stat_activity\` (not \`pg_stat_statements\`) for slow query detection — it runs correctly even when \`pg_stat_statements\` is unavailable. \`statStatements\` and \`queryPlanStats\` require the \`pg_stat_statements\` extension and return a structured \`QUERY_ERROR\` if it is not installed.
 
-**Top-Level Aliases**: \`pg.explain()\`, \`pg.explainAnalyze()\`, \`pg.cacheHitRatio()\`, \`pg.indexStats()\`, \`pg.tableStats()\`, \`pg.indexRecommendations()\`, \`pg.bloatCheck()\`, \`pg.vacuumStats()\`, \`pg.unusedIndexes()\`, \`pg.duplicateIndexes()\`, \`pg.seqScanTables()\`, \`pg.diagnoseDatabasePerformance()\`, \`pg.detectQueryAnomalies()\`, \`pg.detectBloatRisk()\`, \`pg.detectConnectionSpike()\``,
-  ],
-  [
-    "pgcrypto",
-    `# pgcrypto Tools
+**Top-Level Aliases**: \`pg.explain()\`, \`pg.explainAnalyze()\`, \`pg.cacheHitRatio()\`, \`pg.indexStats()\`, \`pg.tableStats()\`, \`pg.indexRecommendations()\`, \`pg.bloatCheck()\`, \`pg.vacuumStats()\`, \`pg.unusedIndexes()\`, \`pg.duplicateIndexes()\`, \`pg.seqScanTables()\`, \`pg.diagnoseDatabasePerformance()\`, \`pg.detectQueryAnomalies()\`, \`pg.detectBloatRisk()\`, \`pg.detectConnectionSpike()\``],
+  ["pgcrypto", `# pgcrypto Tools
 
 Core: \`createExtension()\`, \`hash()\`, \`hmac()\`, \`encrypt()\`, \`decrypt()\`, \`genRandomUuid()\`, \`genRandomBytes()\`, \`genSalt()\`, \`crypt()\`
 
@@ -600,11 +526,8 @@ Core: \`createExtension()\`, \`hash()\`, \`hmac()\`, \`encrypt()\`, \`decrypt()\
 
 **Top-Level Aliases**: \`pg.pgcryptoHash()\`, \`pg.pgcryptoEncrypt()\`, \`pg.pgcryptoDecrypt()\`, \`pg.pgcryptoGenRandomUuid()\`, etc.
 
-**Discovery**: \`pg.pgcrypto.help()\` returns \`{methods, methodAliases, examples}\` object`,
-  ],
-  [
-    "postgis",
-    `# PostGIS Tools
+**Discovery**: \`pg.pgcrypto.help()\` returns \`{methods, methodAliases, examples}\` object`],
+  ["postgis", `# PostGIS Tools
 
 **Geometry Creation:**
 
@@ -636,11 +559,8 @@ Core: \`createExtension()\`, \`hash()\`, \`hmac()\`, \`encrypt()\`, \`decrypt()\
 - \`pg_postgis_create_extension\`: Enable PostGIS extension (idempotent). Returns \`{alreadyExists: true}\` when already installed
 - \`pg_geo_index_optimize\`: Analyze spatial indexes. Without \`table\` param, analyzes all spatial indexes. Returns structured error (\`TABLE_NOT_FOUND\`) if specified table has no spatial columns or indexes
 
-**Code Mode Aliases:** \`pg.postgis.addColumn()\` → \`geometryColumn\`, \`pg.postgis.indexOptimize()\` → \`geoIndexOptimize\`, \`pg.postgis.geoCluster()\` → \`pg_geo_cluster\`, \`pg.postgis.geoTransform()\` → \`pg_geo_transform\`. Note: \`pg.{group}.help()\` returns \`{methods, methodAliases, examples}\``,
-  ],
-  [
-    "schema",
-    `# Schema Tools
+**Code Mode Aliases:** \`pg.postgis.addColumn()\` → \`geometryColumn\`, \`pg.postgis.indexOptimize()\` → \`geoIndexOptimize\`, \`pg.postgis.geoCluster()\` → \`pg_geo_cluster\`, \`pg.postgis.geoTransform()\` → \`pg_geo_transform\`. Note: \`pg.{group}.help()\` returns \`{methods, methodAliases, examples}\``],
+  ["schema", `# Schema Tools
 
 Core: \`listSchemas()\`, \`createSchema()\`, \`dropSchema()\`, \`listViews()\`, \`createView()\`, \`dropView()\`, \`listSequences()\`, \`createSequence()\`, \`dropSequence()\`, \`listFunctions()\`, \`listTriggers()\`, \`listConstraints()\`
 
@@ -661,11 +581,8 @@ Response Structures:
 
 📦 **AI-Optimized Payloads**: \`listViews\`, \`listSequences\`, \`listFunctions\`, \`listTriggers\`, and \`listConstraints\` all default to a 50-row limit. Returns \`truncated: true\` + \`totalCount\` when applicable (for views and sequences) or \`limit\` parameter to indicate sizing. Use \`limit: 0\` for all
 
-**Discovery**: \`pg.schema.help()\` returns \`{methods, methodAliases, examples}\` object`,
-  ],
-  [
-    "stats",
-    `# Stats Tools
+**Discovery**: \`pg.schema.help()\` returns \`{methods, methodAliases, examples}\` object`],
+  ["stats", `# Stats Tools
 
 - All stats tools support \`schema.table\` format (auto-parsed, embedded schema takes priority over explicit \`schema\` param)
 - \`descriptive\`: Returns nested \`statistics\` object containing \`count\`, \`min\`, \`max\`, \`avg\`, \`stddev\`, \`variance\`, \`sum\`, \`mode\`. Access via \`desc.statistics.avg\` (note: uses \`avg\` for mean).
@@ -699,11 +616,8 @@ Response Structures:
 - \`pg_stats_summary({ table, columns?, where? })\`: Summary statistics for multiple numeric columns. Defaults to all numeric columns if \`columns\` omitted. Returns \`{success, table, summaries: [{column, count, avg, min, max, stddev}]}\`
 
 **Top-Level Aliases**: \`pg.descriptive()\`, \`pg.percentiles()\`, \`pg.correlation()\`, \`pg.regression()\`, \`pg.timeSeries()\`, \`pg.distribution()\`, \`pg.hypothesis()\`, \`pg.sampling()\`
-**Note**: All newer tools (e.g., window functions, outlier detection, advanced analysis) must be accessed via their group namespace: \`pg.stats.rowNumber()\`, \`pg.stats.ntile()\`, \`pg.stats.outliers()\`, etc.`,
-  ],
-  [
-    "text",
-    `# Text Tools
+**Note**: All newer tools (e.g., window functions, outlier detection, advanced analysis) must be accessed via their group namespace: \`pg.stats.rowNumber()\`, \`pg.stats.ntile()\`, \`pg.stats.outliers()\`, etc.`],
+  ["text", `# Text Tools
 
 - \`pg_text_search\`/\`pg_text_rank\`: Column must be \`text\` type—pre-built \`tsvector\` columns are **not** supported (wrap with \`to_tsvector()\` fails on tsvector input). Use \`pg_read_query\` with raw FTS SQL for tsvector columns
 - \`pg_create_fts_index\`: Returns \`{success, index, config, skipped}\`. \`skipped: true\` = index already existed (IF NOT EXISTS). \`ifNotExists\` defaults to \`true\`
@@ -718,11 +632,8 @@ Defaults: \`threshold\`=0.3 (use 0.1-0.2 for partial), \`maxDistance\`=3 (use 5+
 - \`pg_text_normalize\`: Removes accents only (unaccent). Does NOT lowercase/trim.
 - 📍 **Table vs Standalone**: \`normalize\`, \`sentiment\`, \`toVector\`, \`toQuery\`, \`searchConfig\` are standalone (text input only). For phonetic matching: use \`pg_fuzzy_match\` with \`method: 'soundex'|'metaphone'\` (direct MCP), or \`pg.text.soundex()\`/\`pg.text.metaphone()\` (Code Mode convenience wrappers that call fuzzyMatch internally).
 
-**Top-Level Aliases**: \`pg.textSearch()\`, \`pg.textRank()\`, \`pg.textHeadline()\`, \`pg.textNormalize()\`, \`pg.textSentiment()\`, \`pg.textToVector()\`, \`pg.textToQuery()\`, \`pg.textSearchConfig()\`, \`pg.textTrigramSimilarity()\`, \`pg.textFuzzyMatch()\`, \`pg.textLikeSearch()\`, \`pg.textRegexpMatch()\`, \`pg.textCreateFtsIndex()\``,
-  ],
-  [
-    "transactions",
-    `# Transactions
+**Top-Level Aliases**: \`pg.textSearch()\`, \`pg.textRank()\`, \`pg.textHeadline()\`, \`pg.textNormalize()\`, \`pg.textSentiment()\`, \`pg.textToVector()\`, \`pg.textToQuery()\`, \`pg.textSearchConfig()\`, \`pg.textTrigramSimilarity()\`, \`pg.textFuzzyMatch()\`, \`pg.textLikeSearch()\`, \`pg.textRegexpMatch()\`, \`pg.textCreateFtsIndex()\``],
+  ["transactions", `# Transactions
 
 Core: \`begin()\`, \`status()\`, \`commit()\`, \`rollback()\`, \`savepoint()\`, \`rollbackTo()\`, \`release()\`, \`execute()\`
 
@@ -764,11 +675,8 @@ Core: \`begin()\`, \`status()\`, \`commit()\`, \`rollback()\`, \`savepoint()\`, 
 - \`savepoint/release/rollbackTo\`: \`{success, transactionId, savepoint, message}\`
 - \`execute\`: \`{success, statementsExecuted, results: [{sql, rowsAffected, rowCount, rows?}], transactionId?, autoRolledBack?, statementsTotal?, failedStatement?}\`
 
-**Discovery**: \`pg.transactions.help()\` returns \`{methods, methodAliases, examples}\``,
-  ],
-  [
-    "vector",
-    `# Vector Tools
+**Discovery**: \`pg.transactions.help()\` returns \`{methods, methodAliases, examples}\``],
+  ["vector", `# Vector Tools
 
 ⚠️ **Large Vectors**: Direct MCP tool calls may truncate vectors >256 dimensions due to JSON-RPC message size limits. For vectors ≥256 dimensions (e.g., OpenAI 1536-dim, local 384-dim), use Code Mode: \`await pg.vector.search({table, column, vector, limit})\`
 
@@ -789,6 +697,5 @@ Core: \`begin()\`, \`status()\`, \`commit()\`, \`rollback()\`, \`savepoint()\`, 
 - \`pg_vector_validate\`: Returns \`{valid: bool, vectorDimensions}\`. Empty vector \`[]\` returns \`{valid: true, vectorDimensions: 0}\`
 - ⛔ \`pg_vector_embed\`: Demo only (hash-based). Use OpenAI/Cohere for production.
 - \`pg_hybrid_search\`: Supports \`schema.table\` format (auto-parsed). Combines vector similarity and full-text search with weighted scoring. ⚠️ Text query param is \`textQuery\` (aliases: \`queryText\`, \`query\`). \`textColumn\` auto-detects type: uses tsvector columns directly, wraps text columns with \`to_tsvector()\`. Code mode alias: \`pg.hybridSearch()\` → \`pg.vector.hybridSearch()\`
-- 📝 **Error Handling & Validation**: Vector tools return structured validation errors (\`{success: false, error: "..."}\`) for dimension mismatches. Zod validation has been strictly enforced to eliminate internal framework refine leaks (no \`_truncated\` exposure in outputs). Token clamping on vector size uses strict payload \`limit\` parameters.`,
-  ],
+- 📝 **Error Handling & Validation**: Vector tools return structured validation errors (\`{success: false, error: "..."}\`) for dimension mismatches. Zod validation has been strictly enforced to eliminate internal framework refine leaks (no \`_truncated\` exposure in outputs). Token clamping on vector size uses strict payload \`limit\` parameters.`],
 ]);

--- a/src/constants/server-instructions/kcache.md
+++ b/src/constants/server-instructions/kcache.md
@@ -2,9 +2,9 @@
 
 Core: `createExtension()`, `queryStats()`, `topCpu()`, `topIo()`, `databaseStats()`, `resourceAnalysis()`, `reset()`
 
-- `pg_kcache_query_stats`: `limit` param (default: 5, max: 10). Returns `truncated` + `totalCount` when limited. `orderBy`: 'total_time' (default), 'cpu_time', 'reads', 'writes'. `queryPreviewLength`: chars for query preview (default: 100, max: 500, 0 for full). `compact`: boolean (default: true, omits query_preview text and 0/empty fields). ⛔ 'calls' NOT valid for orderBy—use `minCalls` param
-- `pg_kcache_resource_analysis`: `limit` param (default: 5, max: 10). Returns `truncated` + `totalCount` when limited. `minCalls`, `queryPreviewLength`, and `compact` supported. Classifies queries as 'CPU-bound', 'I/O-bound', or 'Balanced'
-- `pg_kcache_top_cpu`: Top CPU-consuming queries. `limit` param (default: 5, max: 10). `queryPreviewLength` and `compact` supported. Returns `truncated` + `totalCount` when limited
-- `pg_kcache_top_io`: `type`/`ioType` (alias): 'reads', 'writes', 'both' (default). `limit` param (default: 5, max: 10). `queryPreviewLength` and `compact` supported. Returns `truncated` + `totalCount` when limited
+- `pg_kcache_query_stats`: `limit` param (default: 5, max: 100). Returns `truncated` + `totalCount` when limited. `orderBy`: 'total_time' (default), 'cpu_time', 'reads', 'writes'. `queryPreviewLength`: chars for query preview (default: 100, max: 500, 0 for full). `compact`: boolean (default: true, omits 0/empty fields). ⛔ 'calls' NOT valid for orderBy—use `minCalls` param
+- `pg_kcache_resource_analysis`: `limit` param (default: 5, max: 100). Returns `truncated` + `totalCount` when limited. `minCalls`, `queryPreviewLength`, and `compact` supported. Classifies queries as 'CPU-bound', 'I/O-bound', or 'Balanced'
+- `pg_kcache_top_cpu`: Top CPU-consuming queries. `limit` param (default: 5, max: 100). `queryPreviewLength` and `compact` supported. Returns `truncated` + `totalCount` when limited
+- `pg_kcache_top_io`: `type`/`ioType` (alias): 'reads', 'writes', 'both' (default). `limit` param (default: 5, max: 100). `queryPreviewLength` and `compact` supported. Returns `truncated` + `totalCount` when limited
 - `pg_kcache_database_stats`: Aggregated CPU/IO stats per database. Optional `database` param to filter specific db. `compact`: boolean (default: true, omits 0/empty fields to save tokens)
 - `pg_kcache_reset`: Resets pg_stat_kcache AND pg_stat_statements statistics

--- a/src/constants/server-instructions/performance.md
+++ b/src/constants/server-instructions/performance.md
@@ -26,7 +26,7 @@ Aliases: `cacheStats`→`cacheHitRatio`, `queryStats`→`statStatements`, `activ
 - `locks({ showBlocked?, limit? })`: Default 100 rows, **max 100**. Returns `count` + `truncated`. `limit: 0` returns up to the 100-row cap. `showBlocked: true` returns blocking/blocked query pairs instead of the full lock list
 - `statActivity({ includeIdle?, limit?, truncateQuery? })`: Default 100 connections (excludes idle), **max 100**, queries truncated to 100 chars. Returns `count`, `truncated`, and `backgroundWorkers`. `limit: 0` returns up to the 100-row cap; `includeIdle: true` to include idle connections
 - `detectQueryAnomalies({ threshold?, minCalls? })`: `threshold` must be 0.5–10 (default 2.0); `minCalls` must be 1–10000 (default 10). Out-of-range values return a structured validation error
-- `detectBloatRisk({ minRows?, schema? })`: `minRows` must be 0–1,000,000 (default 1000). Nonexistent `schema` returns a structured `NOT_FOUND` error.
+- `detectBloatRisk({ minRows?, schema? })`: `minRows` must be 0–1,000,000 (default 1000). Nonexistent `schema` returns an empty array instead of a structured error.
 - `detectConnectionSpike({ warningPercent? })`: Default 70. Flags users/apps holding ≥ `warningPercent`% of connections. Value is clamped to 10–100 (not `threshold` — that key is ignored)
 
 📍 **Code Mode Note**: `pg_performance_baseline` → `pg.performance.baseline({ name? })` (not `performanceBaseline`). Optional `name` param labels the snapshot; defaults to an ISO timestamp. `indexRecommendations` accepts `query` alias for `sql`

--- a/test-server/code-map.md
+++ b/test-server/code-map.md
@@ -308,7 +308,7 @@ Per-group Zod schema files (unlike mysql-mcp's monolithic 72KB file):
 
 ## Resources (`src/adapters/postgresql/resources/`)
 
-22 data resources + 22 help resources providing read-only metadata and agent guidance:
+22 data resources + 21 help resources providing read-only metadata and agent guidance:
 
 ### Data Resources
 
@@ -344,7 +344,7 @@ Per-group Zod schema files (unlike mysql-mcp's monolithic 72KB file):
 | `postgres://help`         | `server-instructions/overview.md` + `gotchas.md` | Gotchas, aliases, Code Mode API — always available     |
 | `postgres://help/{group}` | `server-instructions/{group}.md`                 | Per-group tool reference — filtered by `--tool-filter` |
 
-22 group-specific help resources (one per tool group). Only groups enabled by `--tool-filter` are registered.
+20 group-specific help resources. Only groups enabled by `--tool-filter` are registered. The `core` and `codemode` tools are covered by the global `postgres://help` resource.
 
 ---
 

--- a/tests/e2e/payloads-transactions.spec.ts
+++ b/tests/e2e/payloads-transactions.spec.ts
@@ -7,11 +7,7 @@
 
 import { test, expect } from "./fixtures.js";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import {
-  createClient,
-  callToolAndParse,
-  expectSuccess,
-} from "./helpers.js";
+import { createClient, callToolAndParse, expectSuccess } from "./helpers.js";
 
 test.describe.configure({ mode: "serial" });
 


### PR DESCRIPTION
# v3.0.6 - KCache and Anomaly Detection Patch

### Highlights

- **KCache Optimization**: Ensured `query_preview` preservation and increased API bounds.
- **Security Hardening**: Pinned `hono` to `4.12.12` to mitigate middleware vulnerabilities.
- **Core Stability**: Constrained DDL validations and improved anomaly detection edge cases.

### Security

- **hono**: Pinned to `4.12.12` to address moderate vulnerabilities including path traversal and middleware bypass.

### Changed

- **Dependencies**: Bumped `@vitest/coverage-v8`, `typescript-eslint`, and `vitest`.
- **Dockerfile**: Extracted duplicated CVE patch instructions into `scripts/patch-npm-deps.sh` to eliminate stage drift and enforce cache purging.

### Fixed

- **anomaly-detection**: Modified `pg_detect_bloat_risk` to return empty responses instead of validation errors on nonexistent schemas.
- **caching**: Added robust validation for `METADATA_CACHE_TTL_MS` to prevent cache expiration failures.
- **core**: Removed `.unknown()` from column type schemas to constrain default values and prevent DDL validation errors.
- **kcache**: Ensured `query_preview` remains preserved during compact payload generation across CPU, IO, and query tools.
- **kcache**: Increased API parameter bounds from 10 to 100 and improved property aliasing.
- **kcache**: Added `coerceNumber` data preprocessing to all numeric thresholds to properly handle string inputs.
- **partitioning**: Patched syntax errors by escaping embedded single quotes within DDL fragment values.

---

[Full Compare](https://github.com/neverinfamous/postgres-mcp/compare/v3.0.5...v3.0.6)

```bash
docker pull writenotenow/postgres-mcp:v3.0.6
```
